### PR TITLE
Fixed 'after' not excluding the indicated cursor value

### DIFF
--- a/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -112,7 +112,7 @@ static class ConnectionConverter
         int skip;
         if (before == null)
         {
-            skip = after.GetValueOrDefault(0);
+            skip = after + 1 ?? 0;
         }
         else
         {


### PR DESCRIPTION
Fixes #17 