### PR TITLE
Increase ExpressionBuilder and WhereExpression[Graph] access from internal to public

### DIFF
--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -1,9 +1,8 @@
 <!--
 This file was generate by MarkdownSnippets.
-Source File: \pages\configuration.source.md
+Source File: /pages/configuration.source.md
 To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).
 -->
-
 # Configuration
 
 Configuration requires an instance of `Microsoft.EntityFrameworkCore.Metadata.IModel`. It can be extracted from a DbContext instance via the `DbContext.Model` property. Unfortunately EntityFramework conflates configuration with runtime in its API. So `DbContext` is the main API used at runtime, but it also contains the configuration API via the `OnModelCreating` method. As such a DbContext needs to be instantiated and disposed for the purposes of IModel construction. One possible approach is via a static field on the DbContext.
@@ -209,7 +208,7 @@ public class GraphQlController :
         JObject variables,
         CancellationToken cancellation)
     {
-        var executionOptions = new ExecutionOptions
+        var options = new ExecutionOptions
         {
             Schema = schema,
             Query = query,
@@ -223,8 +222,7 @@ public class GraphQlController :
 #endif
         };
 
-        var result = await executer.ExecuteAsync(executionOptions)
-            ;
+        var result = await executer.ExecuteAsync(options);
 
         if (result.Errors?.Count > 0)
         {
@@ -252,7 +250,7 @@ public class GraphQlController :
     }
 }
 ```
-<sup>[snippet source](/src/SampleWeb/GraphQlController.cs#L11-L103)</sup>
+<sup>[snippet source](/src/SampleWeb/GraphQlController.cs#L11-L102)</sup>
 <!-- endsnippet -->
 
 Note that the instance of the DataContext is passed to the [GraphQL .net User Context](https://graphql-dotnet.github.io/docs/getting-started/user-context).
@@ -275,7 +273,7 @@ public class Query :
                 return dataContext.Companies;
             });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L5-L21)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L22)</sup>
 <!-- endsnippet -->
 
 
@@ -394,6 +392,33 @@ query {
     }
 
     [Fact]
+    public async Task Get_employee_summary()
+    {
+        var query = @"
+query {
+  employeeSummary {
+    companyId
+    averageAge
+  }
+}";
+        var response = await ClientQueryExecutor.ExecuteGet(client, query);
+        response.EnsureSuccessStatusCode();
+        var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+        var expected = JObject.FromObject(new
+        {
+            data = new
+            {
+                employeeSummary = new[] {
+                  new { companyId = 1, averageAge = 28.0 },
+                  new { companyId = 4, averageAge = 34.0 }
+                }
+            }
+        });
+        Assert.Equal(expected.ToString(), result.ToString());
+    }
+
+    [Fact]
     public async Task Post()
     {
         var query = @"
@@ -482,7 +507,7 @@ subscription {
     }
 }
 ```
-<sup>[snippet source](/src/SampleWeb.Tests/GraphQlControllerTests.cs#L12-L211)</sup>
+<sup>[snippet source](/src/SampleWeb.Tests/GraphQlControllerTests.cs#L12-L238)</sup>
 <!-- endsnippet -->
 
 
@@ -501,8 +526,7 @@ public static async Task<ExecutionResult> ExecuteWithErrorCheck(this IDocumentEx
 {
     Guard.AgainstNull(nameof(documentExecuter), documentExecuter);
     Guard.AgainstNull(nameof(executionOptions), executionOptions);
-    var executionResult = await documentExecuter.ExecuteAsync(executionOptions)
-        ;
+    var executionResult = await documentExecuter.ExecuteAsync(executionOptions);
 
     var errors = executionResult.Errors;
     if (errors != null && errors.Count > 0)
@@ -518,5 +542,5 @@ public static async Task<ExecutionResult> ExecuteWithErrorCheck(this IDocumentEx
     return executionResult;
 }
 ```
-<sup>[snippet source](/src/GraphQL.EntityFramework/GraphQlExtensions.cs#L9-L32)</sup>
+<sup>[snippet source](/src/GraphQL.EntityFramework/GraphQlExtensions.cs#L9-L31)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -1,11 +1,9 @@
 <!--
 This file was generate by MarkdownSnippets.
-Source File: \pages\defining-graphs.source.md
+Source File: /pages/defining-graphs.source.md
 To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).
 -->
-
 # Defining Graphs
-
 
 ## Includes and Navigation properties.
 
@@ -17,9 +15,9 @@ In the context of GraphQL, Root Graph is the entry point to performing the initi
 
 When performing a query there are several approaches to [Loading Related Data](https://docs.microsoft.com/en-us/ef/core/querying/related-data)
 
- * **Eager loading** means that the related data is loaded from the database as part of the initial query.
- * **Explicit loading** means that the related data is explicitly loaded from the database at a later time.
- * **Lazy loading** means that the related data is transparently loaded from the database when the navigation property is accessed.
+- **Eager loading** means that the related data is loaded from the database as part of the initial query.
+- **Explicit loading** means that the related data is explicitly loaded from the database at a later time.
+- **Lazy loading** means that the related data is transparently loaded from the database when the navigation property is accessed.
 
 Ideally, all navigation properties would be eagerly loaded as part of the root query. However determining what navigation properties to eagerly is difficult in the context of GraphQL. The reason is, given the returned hierarchy of data is dynamically defined by the requesting client, the root query cannot know what properties to include. To work around this GraphQL.EntityFramework interrogates the incoming query to derive the includes. So for example take the following query
 
@@ -45,13 +43,11 @@ context.Heros
         .Include("Friends.Address");
 ```
 
-The string for the include is taken from the field name when using `AddNavigationField` or `AddNavigationConnectionField` with the first character upper cased. This value can be overridden using the optional parameter `includeNames` .  Note that  `includeNames` is an `IEnumerable<string>` so that multiple navigation properties can optionally be included for a single node.
-
+The string for the include is taken from the field name when using `AddNavigationField` or `AddNavigationConnectionField` with the first character upper cased. This value can be overridden using the optional parameter `includeNames` . Note that `includeNames` is an `IEnumerable<string>` so that multiple navigation properties can optionally be included for a single node.
 
 ## Fields
 
 Queries in GraphQL.net are defined using the [Fields API](https://graphql-dotnet.github.io/docs/getting-started/introduction#queries). Fields can be mapped to Entity Framework by using `IEfGraphQLService`. `IEfGraphQLService` can be used in either a root query or a nested query via dependency injection. Alternatively the base type `EfObjectGraphType` or `EfObjectGraphType<TSource>` can be used for root or nested graphs respectively. The below samples all use the base type approach as it results in slightly less code.
-
 
 ### Root Query
 
@@ -87,7 +83,6 @@ public class Query :
 
 `AddSingleField` will result in a single matching being found and returned. This approach uses [`IQueryable<T>.SingleOrDefaultAsync`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.entityframeworkqueryableextensions.singleordefaultasync) as such, if no records are found a null will be returned, and if multiple records match then an exception will be thrown.
 
-
 ### Typed Graph
 
 <!-- snippet: typedGraph -->
@@ -113,12 +108,9 @@ public class CompanyGraph :
 <sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L27)</sup>
 <!-- endsnippet -->
 
-
 ## Connections
 
-
 ### Root Query
-
 
 #### Graph Type
 
@@ -142,7 +134,6 @@ public class Query :
 ```
 <sup>[snippet source](/src/Snippets/ConnectionRootQuery.cs#L6-L24)</sup>
 <!-- endsnippet -->
-
 
 #### Request
 
@@ -170,7 +161,6 @@ public class Query :
   }
 }
 ```
-
 
 #### Response
 
@@ -217,7 +207,6 @@ public class Query :
 }
 ```
 
-
 ### Typed Graph
 
 <!-- snippet: ConnectionTypedGraph -->
@@ -237,8 +226,8 @@ public class CompanyGraph :
 <sup>[snippet source](/src/Snippets/ConnectionTypedGraph.cs#L7-L21)</sup>
 <!-- endsnippet -->
 
-
 ## Enums
+
 ```csharp
 public class DayOfTheWeekGraph : EnumerationGraphType<DayOfTheWeek>
 {
@@ -248,7 +237,7 @@ public class DayOfTheWeekGraph : EnumerationGraphType<DayOfTheWeek>
 ```cs
 public class ExampleGraph : ObjectGraphType<Example>
 {
-    public ExampleGraph() 
+    public ExampleGraph()
     {
         Field(x => x.DayOfTheWeek, type: typeof(DayOfTheWeekGraph));
     }
@@ -256,3 +245,42 @@ public class ExampleGraph : ObjectGraphType<Example>
 ```
 
 - [GraphQL .NET - Schema Types / Enumerations](https://graphql-dotnet.github.io/docs/getting-started/schema-types/#enumerations)
+
+## Manually Apply `WhereExpression`
+
+In some cases, you may want to use `Field` instead of `AddQueryField`/`AddSingleField`/etc but still would like to use apply the `where` argument. This can be useful when the returned `Graph` type is not for an entity (for example, aggregate results). To support this, you must:
+
+- Add the `WhereExpressionGraph` argument
+- Apply the `where` argument expression using `ExpressionBuilder<T>.BuildPredicate(whereExpression)`
+
+```cs
+Field<ListGraphType<EmployeeSummaryGraph>>(
+    name: "employeeSummary",
+    arguments: new QueryArguments(
+        new QueryArgument<ListGraphType<WhereExpressionGraph>> { Name = "where" }
+    ),
+    resolve: context =>
+    {
+        var dataContext = (MyDataContext) context.UserContext;
+        IQueryable<Employee> query = dataContext.Employees;
+
+        if (context.HasArgument("where"))
+        {
+            var whereExpressions = context.GetArgument<List<WhereExpression>>("where");
+            foreach (var whereExpression in whereExpressions)
+            {
+                var predicate = ExpressionBuilder<Employee>.BuildPredicate(whereExpression);
+                query = query.Where(predicate);
+            }
+        }
+
+        var results = from q in query
+                        group q by new { q.CompanyId } into g
+                        select new EmployeeSummary {
+                        CompanyId = g.Key.CompanyId,
+                        AverageAge = g.Average(x => x.Age),
+                        };
+
+        return results;
+    });
+```

--- a/pages/defining-graphs.source.md
+++ b/pages/defining-graphs.source.md
@@ -1,6 +1,5 @@
 # Defining Graphs
 
-
 ## Includes and Navigation properties.
 
 Entity Framework has the concept of [Navigation Properties](https://docs.microsoft.com/en-us/ef/core/modeling/relationships):
@@ -11,9 +10,9 @@ In the context of GraphQL, Root Graph is the entry point to performing the initi
 
 When performing a query there are several approaches to [Loading Related Data](https://docs.microsoft.com/en-us/ef/core/querying/related-data)
 
- * **Eager loading** means that the related data is loaded from the database as part of the initial query.
- * **Explicit loading** means that the related data is explicitly loaded from the database at a later time.
- * **Lazy loading** means that the related data is transparently loaded from the database when the navigation property is accessed.
+- **Eager loading** means that the related data is loaded from the database as part of the initial query.
+- **Explicit loading** means that the related data is explicitly loaded from the database at a later time.
+- **Lazy loading** means that the related data is transparently loaded from the database when the navigation property is accessed.
 
 Ideally, all navigation properties would be eagerly loaded as part of the root query. However determining what navigation properties to eagerly is difficult in the context of GraphQL. The reason is, given the returned hierarchy of data is dynamically defined by the requesting client, the root query cannot know what properties to include. To work around this GraphQL.EntityFramework interrogates the incoming query to derive the includes. So for example take the following query
 
@@ -39,13 +38,11 @@ context.Heros
         .Include("Friends.Address");
 ```
 
-The string for the include is taken from the field name when using `AddNavigationField` or `AddNavigationConnectionField` with the first character upper cased. This value can be overridden using the optional parameter `includeNames` .  Note that  `includeNames` is an `IEnumerable<string>` so that multiple navigation properties can optionally be included for a single node.
-
+The string for the include is taken from the field name when using `AddNavigationField` or `AddNavigationConnectionField` with the first character upper cased. This value can be overridden using the optional parameter `includeNames` . Note that `includeNames` is an `IEnumerable<string>` so that multiple navigation properties can optionally be included for a single node.
 
 ## Fields
 
 Queries in GraphQL.net are defined using the [Fields API](https://graphql-dotnet.github.io/docs/getting-started/introduction#queries). Fields can be mapped to Entity Framework by using `IEfGraphQLService`. `IEfGraphQLService` can be used in either a root query or a nested query via dependency injection. Alternatively the base type `EfObjectGraphType` or `EfObjectGraphType<TSource>` can be used for root or nested graphs respectively. The below samples all use the base type approach as it results in slightly less code.
-
 
 ### Root Query
 
@@ -55,22 +52,17 @@ snippet: rootQuery
 
 `AddSingleField` will result in a single matching being found and returned. This approach uses [`IQueryable<T>.SingleOrDefaultAsync`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.entityframeworkqueryableextensions.singleordefaultasync) as such, if no records are found a null will be returned, and if multiple records match then an exception will be thrown.
 
-
 ### Typed Graph
 
 snippet: typedGraph
 
-
 ## Connections
 
-
 ### Root Query
-
 
 #### Graph Type
 
 snippet: ConnectionRootQuery
-
 
 #### Request
 
@@ -98,7 +90,6 @@ snippet: ConnectionRootQuery
   }
 }
 ```
-
 
 #### Response
 
@@ -145,13 +136,12 @@ snippet: ConnectionRootQuery
 }
 ```
 
-
 ### Typed Graph
 
 snippet: ConnectionTypedGraph
 
-
 ## Enums
+
 ```csharp
 public class DayOfTheWeekGraph : EnumerationGraphType<DayOfTheWeek>
 {
@@ -161,7 +151,7 @@ public class DayOfTheWeekGraph : EnumerationGraphType<DayOfTheWeek>
 ```cs
 public class ExampleGraph : ObjectGraphType<Example>
 {
-    public ExampleGraph() 
+    public ExampleGraph()
     {
         Field(x => x.DayOfTheWeek, type: typeof(DayOfTheWeekGraph));
     }
@@ -169,3 +159,42 @@ public class ExampleGraph : ObjectGraphType<Example>
 ```
 
 - [GraphQL .NET - Schema Types / Enumerations](https://graphql-dotnet.github.io/docs/getting-started/schema-types/#enumerations)
+
+## Manually Apply `WhereExpression`
+
+In some cases, you may want to use `Field` instead of `AddQueryField`/`AddSingleField`/etc but still would like to use apply the `where` argument. This can be useful when the returned `Graph` type is not for an entity (for example, aggregate results). To support this, you must:
+
+- Add the `WhereExpressionGraph` argument
+- Apply the `where` argument expression using `ExpressionBuilder<T>.BuildPredicate(whereExpression)`
+
+```cs
+Field<ListGraphType<EmployeeSummaryGraph>>(
+    name: "employeeSummary",
+    arguments: new QueryArguments(
+        new QueryArgument<ListGraphType<WhereExpressionGraph>> { Name = "where" }
+    ),
+    resolve: context =>
+    {
+        var dataContext = (MyDataContext) context.UserContext;
+        IQueryable<Employee> query = dataContext.Employees;
+
+        if (context.HasArgument("where"))
+        {
+            var whereExpressions = context.GetArgument<List<WhereExpression>>("where");
+            foreach (var whereExpression in whereExpressions)
+            {
+                var predicate = ExpressionBuilder<Employee>.BuildPredicate(whereExpression);
+                query = query.Where(predicate);
+            }
+        }
+
+        var results = from q in query
+                        group q by new { q.CompanyId } into g
+                        select new EmployeeSummary {
+                        CompanyId = g.Key.CompanyId,
+                        AverageAge = g.Average(x => x.Age),
+                        };
+
+        return results;
+    });
+```

--- a/pages/filters.md
+++ b/pages/filters.md
@@ -1,9 +1,8 @@
 <!--
 This file was generate by MarkdownSnippets.
-Source File: \pages\filters.source.md
+Source File: /pages/filters.source.md
 To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).
 -->
-
 # Filters
 
 Sometimes, in the context of constructing an EF query, it is not possible to know if any given item should be returned in the results. For example when performing authorization where the rules rules are pulled from a different system, and that information does not exist in the database.

--- a/pages/query-usage.md
+++ b/pages/query-usage.md
@@ -1,9 +1,8 @@
 <!--
 This file was generate by MarkdownSnippets.
-Source File: \pages\query-usage.source.md
+Source File: /pages/query-usage.source.md
 To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).
 -->
-
 
 # Query Usage
 

--- a/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using GraphQL.EntityFramework;
 
-static class ExpressionBuilder<T>
+public static class ExpressionBuilder<T>
 {
     public static Expression<Func<T, bool>> BuildPredicate(WhereExpression where)
     {

--- a/src/GraphQL.EntityFramework/Where/Graphs/WhereExpression.cs
+++ b/src/GraphQL.EntityFramework/Where/Graphs/WhereExpression.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using GraphQL.EntityFramework;
 
-class WhereExpression
+public class WhereExpression
 {
     public string Path { get; set; }
     public Comparison? Comparison { get; set; }

--- a/src/GraphQL.EntityFramework/Where/Graphs/WhereExpressionGraph.cs
+++ b/src/GraphQL.EntityFramework/Where/Graphs/WhereExpressionGraph.cs
@@ -1,6 +1,6 @@
 ﻿using GraphQL.Types;
 
-class WhereExpressionGraph :
+public class WhereExpressionGraph :
     InputObjectGraphType<WhereExpression>
 {
     public WhereExpressionGraph()

--- a/src/SampleWeb.Tests/GraphQlControllerTests.cs
+++ b/src/SampleWeb.Tests/GraphQlControllerTests.cs
@@ -120,6 +120,33 @@ query {
     }
 
     [Fact]
+    public async Task Get_employee_summary()
+    {
+        var query = @"
+query {
+  employeeSummary {
+    companyId
+    averageAge
+  }
+}";
+        var response = await ClientQueryExecutor.ExecuteGet(client, query);
+        response.EnsureSuccessStatusCode();
+        var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+        var expected = JObject.FromObject(new
+        {
+            data = new
+            {
+                employeeSummary = new[] {
+                  new { companyId = 1, averageAge = 28.0 },
+                  new { companyId = 4, averageAge = 34.0 }
+                }
+            }
+        });
+        Assert.Equal(expected.ToString(), result.ToString());
+    }
+
+    [Fact]
     public async Task Post()
     {
         var query = @"

--- a/src/SampleWeb/DataContext/Employee.cs
+++ b/src/SampleWeb/DataContext/Employee.cs
@@ -4,4 +4,5 @@
     public int CompanyId { get; set; }
     public Company Company { get; set; }
     public string Content { get; set; }
+    public int Age { get; set; }
 }

--- a/src/SampleWeb/DataContextBuilder.cs
+++ b/src/SampleWeb/DataContextBuilder.cs
@@ -26,13 +26,15 @@ static class DataContextBuilder
         {
             Id = 2,
             CompanyId = company1.Id,
-            Content = "Employee1"
+            Content = "Employee1",
+            Age = 25
         };
         var employee2 = new Employee
         {
             Id = 3,
             CompanyId = company1.Id,
-            Content = "Employee2"
+            Content = "Employee2",
+            Age = 31 
         };
         var company2 = new Company
         {
@@ -43,7 +45,8 @@ static class DataContextBuilder
         {
             Id = 5,
             CompanyId = company2.Id,
-            Content = "Employee4"
+            Content = "Employee4",
+            Age = 34 
         };
         var company3 = new Company
         {

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -8,6 +8,7 @@ public class EmployeeGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
+        Field(x => x.Age);
         AddNavigationField<CompanyGraph, Company>(
             name: "company",
             resolve: context => context.Source.Company);

--- a/src/SampleWeb/Graphs/EmployeeSummaryGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeSummaryGraph.cs
@@ -1,0 +1,18 @@
+using GraphQL.EntityFramework;
+
+public class EmployeeSummaryGraph :
+    EfObjectGraphType<EmployeeSummary>
+{
+    public EmployeeSummaryGraph(IEfGraphQLService graphQlService) :
+        base(graphQlService)
+    {
+        Field(x => x.CompanyId);
+        Field(x => x.AverageAge);
+    }
+}
+
+public class EmployeeSummary
+{
+    public int CompanyId { get; set; }
+    public double AverageAge { get; set; }
+}


### PR DESCRIPTION
#### Description
Increasing the default access of `ExpressionBuilder` and `WhereExpression` will allow direct usage in non-Query/Navigation Fields which is helpful for aggregate/non-entity returning fields.

For example, I expose some `*Summary` fields to provide aggregate rollups of some data, but would like to pass the same `where` argument I pass to the listing fields (ex. `AllBalances`)

For example, this change will allow the following usage:

```c#
Field<ListGraphType<BalanceSummaryGraph>>(
    name: "BalanceSummary",
    arguments: new QueryArguments(
        new QueryArgument<ListGraphType<WhereExpressionGraph>> { Name = "where" }
    ),
    resolve: context =>
    {
        var userContext = (context.UserContext as FinanceUserContext);
        var dbContext = userContext.DbContext;
        var query = dbContext.Balances as IQueryable<Balance>;

        if (context.HasArgument("where"))
        {
            var whereExpressions = context.GetArgument<List<WhereExpression>>("where");
            var predicate = ExpressionBuilder<Balance>.BuildPredicate(where);
            query = query.Where(predicate);
        }

        var results = from q in query
                      group q by new { q.PeriodStart } into g
                      select new BalanceSummary {
                        PeriodStart = g.Key.PeriodStart,
                        Actual = g.Sum(x => x.Actual),
                        Budgeted = g.Sum(x => x.Budgeted),
                        Variance = g.Sum(x => x.Variance)
                      };

        return results;
    });
```

#### The solution

I initially tried to use `AddQueryConnectionField` to add the `BalanceSummary` field and leverage the application of the `where` argument imperatively, but it was raising an exception in `IncludeAppender` probably because the `BalanceSummary` class is not an entity model, but just a DTO/POCO.

```c#
public class BalanceSummaryGraph : ObjectGraphType<BalanceSummary>
{
    public BalanceSummaryGraph()
    {
        Field(x => x.PeriodStart);

        Field(x => x.Actual, nullable: true);
        Field(x => x.Budgeted, nullable: true);
        Field(x => x.Variance, nullable: true);
        Field(x => x.BeginningBalance, nullable: true);
    }
}

public class BalanceSummary
{
    public DateTime PeriodStart { get; set; }

    public decimal? Actual { get; set; }
    public decimal? Budgeted { get; set; }
    public decimal? Variance { get; set; }
    public decimal? BeginningBalance { get; set; }
}
```

Exposing these classes gives greater control when needed as well.
