### PR TITLE
Make GraphType optional

### DIFF
--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -266,7 +266,8 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField<CompanyGraph, Company>(
+        AddQueryField(
+            typeof(CompanyGraph),
             name: "companies",
             resolve: context =>
             {
@@ -274,7 +275,7 @@ public class Query :
                 return dataContext.Companies;
             });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L22)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L23)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -266,16 +266,14 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(
-            typeof(CompanyGraph),
-            name: "companies",
+        AddQueryField(name: "companies",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            });
+            }, graphType: typeof(CompanyGraph));
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L23)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L21)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -266,14 +266,15 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(name: "companies",
+        AddQueryField(
+            name: "companies",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            }, graphType: typeof(CompanyGraph));
+            });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L21)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L6-L22)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -62,14 +62,16 @@ public class Query :
     public Query(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        AddSingleField<CompanyGraph, Company>(
+        AddSingleField(
+            typeof(CompanyGraph),
             name: "company",
             resolve: context =>
             {
                 var dataContext = (DataContext) context.UserContext;
                 return dataContext.Companies;
             });
-        AddQueryField<CompanyGraph, Company>(
+        AddQueryField(
+            typeof(CompanyGraph),
             name: "companies",
             resolve: context =>
             {
@@ -79,7 +81,7 @@ public class Query :
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L29)</sup>
+<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L31)</sup>
 <!-- endsnippet -->
 
 `AddQueryField` will result in all matching being found and returned.

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -62,14 +62,11 @@ public class Query :
     public Query(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        AddSingleField(
-            typeof(CompanyGraph),
-            name: "company",
-            resolve: context =>
-            {
-                var dataContext = (DataContext) context.UserContext;
-                return dataContext.Companies;
-            });
+        AddSingleField(resolve: context =>
+        {
+            var dataContext = (DataContext) context.UserContext;
+            return dataContext.Companies;
+        }, graphType: typeof(CompanyGraph), name: "company");
         AddQueryField(
             typeof(CompanyGraph),
             name: "companies",
@@ -81,7 +78,7 @@ public class Query :
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L31)</sup>
+<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L28)</sup>
 <!-- endsnippet -->
 
 `AddQueryField` will result in all matching being found and returned.
@@ -101,10 +98,8 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<Employee>(
-            typeof(EmployeeGraph),
-            name: "employees",
-            resolve: context => context.Source.Employees);
+        AddNavigationField<Employee>(name: "employees",
+            resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
         AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
@@ -113,7 +108,7 @@ public class CompanyGraph :
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L29)</sup>
+<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L27)</sup>
 <!-- endsnippet -->
 
 
@@ -303,5 +298,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L72-L104)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L69-L101)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -296,5 +296,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L62-L94)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L65-L97)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -139,11 +139,12 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            });
+            },
+            graphType:typeof(CompanyGraph));
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/ConnectionRootQuery.cs#L6-L24)</sup>
+<sup>[snippet source](/src/Snippets/ConnectionRootQuery.cs#L6-L25)</sup>
 <!-- endsnippet -->
 
 
@@ -302,5 +303,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L69-L99)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L71-L101)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -133,14 +133,14 @@ public class Query :
     public Query(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        AddQueryConnectionField<CompanyGraph, Company>(
+        AddQueryConnectionField(
             name: "companies",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
             },
-            graphType:typeof(CompanyGraph));
+            graphType: typeof(CompanyGraph));
     }
 }
 ```
@@ -303,5 +303,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L71-L101)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L72-L104)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -101,7 +101,8 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<EmployeeGraph, Employee>(
+        AddNavigationField<Employee>(
+            typeof(EmployeeGraph),
             name: "employees",
             resolve: context => context.Source.Employees);
         AddNavigationConnectionField<EmployeeGraph, Employee>(
@@ -111,7 +112,7 @@ public class CompanyGraph :
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L27)</sup>
+<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L28)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -105,14 +105,15 @@ public class CompanyGraph :
             typeof(EmployeeGraph),
             name: "employees",
             resolve: context => context.Source.Employees);
-        AddNavigationConnectionField<EmployeeGraph, Employee>(
+        AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
+            typeof(EmployeeGraph),
             includeNames: new[] {"Employees"});
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L28)</sup>
+<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L29)</sup>
 <!-- endsnippet -->
 
 
@@ -230,13 +231,14 @@ public class CompanyGraph :
     public CompanyGraph(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        AddNavigationConnectionField<EmployeeGraph, Employee>(
+        AddNavigationConnectionField(
             name: "employees",
-            resolve: context => context.Source.Employees);
+            resolve: context => context.Source.Employees,
+            typeof(EmployeeGraph));
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/ConnectionTypedGraph.cs#L7-L21)</sup>
+<sup>[snippet source](/src/Snippets/ConnectionTypedGraph.cs#L7-L22)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -101,8 +101,7 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<Employee>(
-            typeof(EmployeeGraph),
+        AddNavigationField<EmployeeGraph, Employee>(
             name: "employees",
             resolve: context => context.Source.Employees);
         AddNavigationConnectionField<EmployeeGraph, Employee>(
@@ -112,7 +111,7 @@ public class CompanyGraph :
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L28)</sup>
+<sup>[snippet source](/src/Snippets/TypedGraph.cs#L7-L27)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -62,21 +62,24 @@ public class Query :
     public Query(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        AddSingleField(resolve: context =>
-        {
-            var dataContext = (DataContext) context.UserContext;
-            return dataContext.Companies;
-        }, graphType: typeof(CompanyGraph), name: "company");
-        AddQueryField(name: "companies",
+        AddSingleField(
             resolve: context =>
             {
                 var dataContext = (DataContext) context.UserContext;
                 return dataContext.Companies;
-            }, graphType: typeof(CompanyGraph));
+            },
+            name: "company");
+        AddQueryField(
+            name: "companies",
+            resolve: context =>
+            {
+                var dataContext = (DataContext) context.UserContext;
+                return dataContext.Companies;
+            });
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L26)</sup>
+<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L31)</sup>
 <!-- endsnippet -->
 
 `AddQueryField` will result in all matching being found and returned.
@@ -96,12 +99,12 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<Employee>(name: "employees",
-            resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
+        AddNavigationField<Employee>(
+            name: "employees",
+            resolve: context => context.Source.Employees);
         AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
-            typeof(EmployeeGraph),
             includeNames: new[] {"Employees"});
     }
 }
@@ -132,12 +135,11 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            },
-            graphType: typeof(CompanyGraph));
+            });
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/ConnectionRootQuery.cs#L6-L25)</sup>
+<sup>[snippet source](/src/Snippets/ConnectionRootQuery.cs#L6-L24)</sup>
 <!-- endsnippet -->
 
 
@@ -227,12 +229,11 @@ public class CompanyGraph :
     {
         AddNavigationConnectionField(
             name: "employees",
-            resolve: context => context.Source.Employees,
-            typeof(EmployeeGraph));
+            resolve: context => context.Source.Employees);
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/ConnectionTypedGraph.cs#L7-L22)</sup>
+<sup>[snippet source](/src/Snippets/ConnectionTypedGraph.cs#L7-L21)</sup>
 <!-- endsnippet -->
 
 

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -67,18 +67,16 @@ public class Query :
             var dataContext = (DataContext) context.UserContext;
             return dataContext.Companies;
         }, graphType: typeof(CompanyGraph), name: "company");
-        AddQueryField(
-            typeof(CompanyGraph),
-            name: "companies",
+        AddQueryField(name: "companies",
             resolve: context =>
             {
                 var dataContext = (DataContext) context.UserContext;
                 return dataContext.Companies;
-            });
+            }, graphType: typeof(CompanyGraph));
     }
 }
 ```
-<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L28)</sup>
+<sup>[snippet source](/src/Snippets/RootQuery.cs#L6-L26)</sup>
 <!-- endsnippet -->
 
 `AddQueryField` will result in all matching being found and returned.
@@ -298,5 +296,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L69-L101)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L62-L94)</sup>
 <!-- endsnippet -->

--- a/pages/defining-graphs.md
+++ b/pages/defining-graphs.md
@@ -297,5 +297,5 @@ Field<ListGraphType<EmployeeSummaryGraph>>(
             };
     });
 ```
-<sup>[snippet source](/src/SampleWeb/Query.cs#L65-L95)</sup>
+<sup>[snippet source](/src/SampleWeb/Query.cs#L69-L99)</sup>
 <!-- endsnippet -->

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
@@ -35,20 +35,6 @@ namespace GraphQL.EntityFramework
             return graph.AddField(field);
         }
 
-        public FieldType AddNavigationField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildNavigationField(name, resolve, includeNames, typeof(TGraph), arguments);
-            return graph.AddField(field);
-        }
-
         FieldType BuildNavigationField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
@@ -10,7 +10,7 @@ namespace GraphQL.EntityFramework
         public FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -23,7 +23,7 @@ namespace GraphQL.EntityFramework
         public FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -42,8 +42,8 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
-            Guard.AgainstNull(nameof(graphType), graphType);
             Guard.AgainstNull(nameof(resolve), resolve);
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             return new FieldType
             {
                 Name = name,
@@ -57,6 +57,7 @@ namespace GraphQL.EntityFramework
                     {
                         return result;
                     }
+
                     return null;
                 })
             };

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
@@ -7,20 +7,6 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public FieldType AddNavigationField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildNavigationField(name, resolve, includeNames, typeof(TGraph), arguments);
-            return graph.AddField(field);
-        }
-
         public FieldType AddNavigationField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             Type graphType,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Navigation.cs
@@ -7,11 +7,10 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public FieldType AddNavigationField<TSource, TReturn>(
-            ObjectGraphType<TSource> graph,
-            Type graphType,
+        public FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -21,11 +20,10 @@ namespace GraphQL.EntityFramework
             return graph.AddField(field);
         }
 
-        public FieldType AddNavigationField<TReturn>(
-            ObjectGraphType graph,
-            Type graphType,
+        public FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -13,7 +13,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
@@ -29,7 +29,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -8,8 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
-            ObjectGraphType graph,
+        public void AddNavigationConnectionField<TGraph, TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -22,11 +21,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<object, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
+        public void AddNavigationConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -39,7 +36,6 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<TSource, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildListConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -52,6 +52,7 @@ namespace GraphQL.EntityFramework
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
             Guard.AgainstNegative(nameof(pageSize), pageSize);
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             var fieldType = GetFieldType<TSource>(name, graphType);
             var builder = ConnectionBuilder<FakeGraph, TSource>.Create(name);
             builder.PageSize(pageSize);

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -55,8 +55,7 @@ namespace GraphQL.EntityFramework
             var fieldType = GetFieldType<TSource>(name, graphType);
             var builder = ConnectionBuilder<FakeGraph, TSource>.Create(name);
             builder.PageSize(pageSize);
-            var fieldTypeField = builder.GetType().GetProperty("FieldType", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-            fieldTypeField.SetValue(builder, fieldType);
+            SetField(builder, fieldType);
             IncludeAppender.SetIncludeMetadata(builder.FieldType, name, includeName);
             builder.ResolveAsync(async context =>
             {
@@ -73,6 +72,12 @@ namespace GraphQL.EntityFramework
                     context.Before);
             });
             return builder;
+        }
+
+        static void SetField(object builder, object fieldType)
+        {
+            var fieldTypeField = builder.GetType().GetProperty("FieldType", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            fieldTypeField.SetValue(builder, fieldType);
         }
 
         static object GetFieldType<TSource>(string name, Type graphType)

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -8,7 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
+        public void AddNavigationConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
@@ -22,10 +22,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<object, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
+        public void AddNavigationConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
@@ -39,7 +38,6 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<TSource, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildListConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -8,7 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public void AddNavigationConnectionField<TGraph, TReturn>(
+        public ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
@@ -22,9 +22,10 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<object, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
+            return connection;
         }
 
-        public void AddNavigationConnectionField<TSource, TGraph, TReturn>(
+        public ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
@@ -38,6 +39,7 @@ namespace GraphQL.EntityFramework
             var connection = BuildListConnectionField<TSource, TGraph, TReturn>(name, resolve, includeNames, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
+            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildListConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationConnection.cs
@@ -9,34 +9,34 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public void AddNavigationConnectionField<TGraph, TReturn>(
+        public void AddNavigationConnectionField<TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, typeof(TGraph));
+            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, graphType);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
 
-        public void AddNavigationConnectionField<TSource, TGraph, TReturn>(
+        public void AddNavigationConnectionField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, typeof(TGraph));
+            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, graphType);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
@@ -46,7 +46,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<string> includeName,
             int pageSize,
-            Type graphType) where TReturn : class
+            Type graphType)
+            where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -7,20 +7,6 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public FieldType AddNavigationField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildNavigationField<object, TGraph, TReturn>(name, resolve, includeNames, arguments);
-            return graph.AddField(field);
-        }
-
         public FieldType AddNavigationField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             Type graphType,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -7,10 +7,11 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
+        public FieldType AddNavigationField<TSource, TReturn>(
+            ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -23,7 +24,7 @@ namespace GraphQL.EntityFramework
         public FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -41,7 +41,7 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments)
             where TReturn : class
         {
-            Guard.AgainstNull(nameof(graphType), graphType);
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             var listGraphType = MakeListGraphType(graphType);
             return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
         }

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -48,20 +48,6 @@ namespace GraphQL.EntityFramework
             return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
         }
 
-        public FieldType AddNavigationField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildNavigationField<TSource, TGraph, TReturn>(name, resolve, includeNames, arguments);
-            return graph.AddField(field);
-        }
-
         FieldType BuildNavigationField<TSource, TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -48,18 +48,6 @@ namespace GraphQL.EntityFramework
             return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
         }
 
-        FieldType BuildNavigationField<TSource, TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            IEnumerable<string> includeNames,
-            IEnumerable<QueryArgument> arguments)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            var listGraphType = typeof(ListGraphType<TGraph>);
-            return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
-        }
-
         FieldType BuildNavigationField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_NavigationList.cs
@@ -7,11 +7,10 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public FieldType AddNavigationField<TSource, TReturn>(
-            ObjectGraphType<TSource> graph,
-            Type graphType,
+        public FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -21,11 +20,10 @@ namespace GraphQL.EntityFramework
             return graph.AddField(field);
         }
 
-        public FieldType AddNavigationField<TReturn>(
-            ObjectGraphType graph,
-            Type graphType,
+        public FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -11,9 +11,9 @@ namespace GraphQL.EntityFramework
     {
         public FieldType AddQueryField<TReturn>(
             ObjectGraphType graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -24,9 +24,9 @@ namespace GraphQL.EntityFramework
 
         public FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -37,9 +37,9 @@ namespace GraphQL.EntityFramework
 
         public FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -13,7 +13,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -26,7 +26,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -39,7 +39,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -55,20 +55,20 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments)
             where TReturn : class
         {
-            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
-            var listGraphType = MakeListGraphType(graphType);
-            return BuildQueryField(name, resolve, arguments, listGraphType);
+            return BuildQueryField(name, resolve, arguments, graphType);
         }
 
         FieldType BuildQueryField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments,
-            Type listGraphType)
+            Type graphType)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
+            var listGraphType = MakeListGraphType(graphType);
             return new FieldType
             {
                 Name = name,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -55,7 +55,7 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments)
             where TReturn : class
         {
-            Guard.AgainstNull(nameof(graphType), graphType);
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             var listGraphType = MakeListGraphType(graphType);
             return BuildQueryField(name, resolve, arguments, listGraphType);
         }

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -60,45 +60,6 @@ namespace GraphQL.EntityFramework
             return BuildQueryField(name, resolve, arguments, listGraphType);
         }
 
-        public FieldType AddQueryField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField<object, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
-        public FieldType AddQueryField<TSource, TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField<TSource, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
-        public FieldType AddQueryField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField<TSource, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
         FieldType BuildQueryField<TSource, TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Queryable.cs
@@ -60,17 +60,6 @@ namespace GraphQL.EntityFramework
             return BuildQueryField(name, resolve, arguments, listGraphType);
         }
 
-        FieldType BuildQueryField<TSource, TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            var listGraphType = MakeListGraphType(typeof(TGraph));
-            return BuildQueryField(name, resolve, arguments, listGraphType);
-        }
-
         FieldType BuildQueryField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -8,10 +8,11 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public void AddQueryConnectionField<TReturn>(ObjectGraphType graph,
+        public void AddQueryConnectionField<TReturn>(
+            ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class
@@ -26,7 +27,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class
@@ -41,7 +42,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -8,8 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
-            ObjectGraphType graph,
+        public void AddQueryConnectionField<TGraph, TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -21,10 +20,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<object, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -37,11 +35,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
+        public void AddQueryConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -53,7 +49,6 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildQueryConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -37,7 +37,8 @@ namespace GraphQL.EntityFramework
             field.AddWhereArgument(arguments);
         }
 
-        public void AddQueryConnectionField<TSource, TReturn>(ObjectGraphType<TSource> graph,
+        public void AddQueryConnectionField<TSource, TReturn>(
+            ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
@@ -55,13 +56,14 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             int pageSize,
-            Type graphType) where TReturn : class
+            Type graphType)
+            where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
             Guard.AgainstNegative(nameof(pageSize), pageSize);
 
-
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             var fieldType = GetFieldType<TSource>(name, graphType);
             var builder = ConnectionBuilder<FakeGraph, TSource>.Create(name);
             builder.PageSize(pageSize);

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -8,13 +8,12 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public void AddQueryConnectionField<TGraph, TReturn>(ObjectGraphType graph,
+        public void AddQueryConnectionField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
@@ -23,14 +22,13 @@ namespace GraphQL.EntityFramework
             field.AddWhereArgument(arguments);
         }
 
-        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public void AddQueryConnectionField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
@@ -39,13 +37,12 @@ namespace GraphQL.EntityFramework
             field.AddWhereArgument(arguments);
         }
 
-        public void AddQueryConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
+        public void AddQueryConnectionField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -63,8 +63,6 @@ namespace GraphQL.EntityFramework
             Guard.AgainstNegative(nameof(pageSize), pageSize);
             var builder = ConnectionBuilder.Create<TGraph, TSource>();
             builder.PageSize(pageSize);
-            //todo:
-            //builder.Bidirectional();
             builder.Name(name);
             builder.Resolve(
                 context =>

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -8,7 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public void AddQueryConnectionField<TGraph, TReturn>(
+        public ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
@@ -21,9 +21,10 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<object, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
+            return connection;
         }
 
-        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -36,9 +37,10 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
+            return connection;
         }
 
-        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -51,6 +53,7 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
+            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildQueryConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_QueryableConnection.cs
@@ -8,7 +8,7 @@ namespace GraphQL.EntityFramework
 {
     partial class EfGraphQLService
     {
-        public ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
+        public void AddQueryConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
@@ -21,10 +21,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<object, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -37,10 +36,9 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
-        public ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        public void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -53,7 +51,6 @@ namespace GraphQL.EntityFramework
             var connection = BuildQueryConnectionField<TSource, TGraph, TReturn>(name, resolve, pageSize);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
-            return connection;
         }
 
         ConnectionBuilder<TGraph, TSource> BuildQueryConnectionField<TSource, TGraph, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
@@ -26,7 +26,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -39,7 +39,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -68,6 +68,8 @@ namespace GraphQL.EntityFramework
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
+
+            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             return new FieldType
             {
                 Name = name,
@@ -90,5 +92,6 @@ namespace GraphQL.EntityFramework
                     })
             };
         }
+
     }
 }

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
@@ -59,16 +59,6 @@ namespace GraphQL.EntityFramework
             return BuildSingleField(name, resolve, arguments, graphType);
         }
 
-        FieldType BuildSingleField<TSource, TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            return BuildSingleField(name, resolve, arguments, typeof(TGraph));
-        }
-
         FieldType BuildSingleField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
@@ -13,7 +13,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -46,17 +46,6 @@ namespace GraphQL.EntityFramework
             Guard.AgainstNull(nameof(graph), graph);
             var field = BuildSingleField(name, resolve, arguments, graphType);
             return graph.AddField(field);
-        }
-
-        FieldType BuildSingleField<TSource, TReturn>(
-            Type graphType,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graphType), graphType);
-            return BuildSingleField(name, resolve, arguments, graphType);
         }
 
         FieldType BuildSingleField<TSource, TReturn>(

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
@@ -48,45 +48,6 @@ namespace GraphQL.EntityFramework
             return graph.AddField(field);
         }
 
-        public FieldType AddSingleField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField<object, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
-        public FieldType AddSingleField<TSource, TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField<TSource, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
-        public FieldType AddSingleField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class
-        {
-            Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField<TSource, TGraph, TReturn>(name, resolve, arguments);
-            return graph.AddField(field);
-        }
-
         FieldType BuildSingleField<TSource, TReturn>(
             Type graphType,
             string name,

--- a/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLService_Single.cs
@@ -12,8 +12,8 @@ namespace GraphQL.EntityFramework
         public FieldType AddSingleField<TReturn>(
             ObjectGraphType graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -25,8 +25,8 @@ namespace GraphQL.EntityFramework
         public FieldType AddSingleField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -38,8 +38,8 @@ namespace GraphQL.EntityFramework
         public FieldType AddSingleField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -16,16 +16,16 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected void AddNavigationConnectionField<TGraph, TReturn>(
+        protected void AddNavigationConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField(this, name, resolve,graphType, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -42,7 +42,7 @@ namespace GraphQL.EntityFramework
         protected FieldType AddNavigationField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -37,7 +37,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField<TGraph, TReturn>(this, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames,graphType:typeof(TGraph));
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -116,7 +116,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddSingleField<TGraph, TReturn>(this, name, resolve);
+            return efGraphQlService.AddSingleField(this, name, resolve: resolve, graphType: typeof(TGraph));
         }
 
         protected FieldType AddSingleField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -29,25 +29,25 @@ namespace GraphQL.EntityFramework
         }
 
         protected FieldType AddNavigationField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name, resolve, graphType, arguments, includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name, resolve, graphType, arguments, includeNames);
         }
 
         protected void AddQueryConnectionField<TReturn>(
@@ -68,16 +68,16 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField(this, graphType, name, resolve, arguments);
+            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments);
         }
 
         protected FieldType AddSingleField<TReturn>(
-            Type graphType,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             string name = nameof(TReturn))
             where TReturn : class
         {
-            return efGraphQlService.AddSingleField(this, name, graphType, resolve);
+            return efGraphQlService.AddSingleField(this, name, resolve, graphType);
         }
     }
 }

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -25,7 +25,7 @@ namespace GraphQL.EntityFramework
             int pageSize = 10)
             where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField(this, name, resolve,graphType, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField(this, name, resolve, graphType, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -50,16 +50,15 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected void AddQueryConnectionField<TGraph, TReturn>(
+        protected void AddQueryConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve,graphType, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -62,16 +62,6 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
-        protected FieldType AddQueryField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddQueryField(this, name: name, resolve: resolve, graphType: typeof(TGraph), arguments: arguments);
-        }
-
         protected FieldType AddQueryField<TReturn>(
             Type graphType,
             string name,
@@ -80,15 +70,6 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddQueryField(this, graphType, name, resolve, arguments);
-        }
-
-        protected FieldType AddSingleField<TGraph, TReturn>(
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            string name = nameof(TReturn))
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddSingleField(this, name, resolve: resolve, graphType: typeof(TGraph));
         }
 
         protected FieldType AddSingleField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -50,14 +50,16 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected void AddQueryConnectionField<TGraph, TReturn>(string name,
+        protected void AddQueryConnectionField<TGraph, TReturn>(
+            string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve,graphType, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -97,7 +97,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField<TGraph, TReturn>(this, name, resolve, arguments);
+            return efGraphQlService.AddQueryField(this, name: name, resolve: resolve, graphType: typeof(TGraph), arguments: arguments);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
         protected void AddNavigationConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
@@ -31,7 +31,7 @@ namespace GraphQL.EntityFramework
         protected FieldType AddNavigationField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -53,7 +53,7 @@ namespace GraphQL.EntityFramework
         protected void AddQueryConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class
@@ -62,9 +62,9 @@ namespace GraphQL.EntityFramework
         }
 
         protected FieldType AddQueryField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
@@ -73,7 +73,7 @@ namespace GraphQL.EntityFramework
 
         protected FieldType AddSingleField<TReturn>(
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             string name = nameof(TReturn))
             where TReturn : class
         {

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
@@ -16,7 +17,7 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected void AddNavigationConnectionField<TGraph, TReturn>(
+        protected ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -25,7 +26,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            return efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -50,14 +51,15 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected void AddQueryConnectionField<TGraph, TReturn>(string name,
+        protected ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
+            string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            return efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -29,17 +29,6 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<object>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames,graphType:typeof(TGraph));
-        }
-
         protected FieldType AddNavigationField<TReturn>(
             Type graphType,
             string name,
@@ -49,23 +38,6 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
-        }
-
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(
-                this,
-                name: name,
-                resolve: resolve,
-                arguments: arguments,
-                includeNames: includeNames,
-                graphType: typeof(TGraph));
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
@@ -17,7 +16,7 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
+        protected void AddNavigationConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -26,7 +25,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField<TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -51,15 +50,14 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
-            string name,
+        protected void AddQueryConnectionField<TGraph, TReturn>(string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField<TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphType.cs
@@ -59,7 +59,13 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField<TGraph, TReturn>(this, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(
+                this,
+                name: name,
+                resolve: resolve,
+                arguments: arguments,
+                includeNames: includeNames,
+                graphType: typeof(TGraph));
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -22,7 +22,8 @@ namespace GraphQL.EntityFramework
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
-            int pageSize = 10) where TReturn : class
+            int pageSize = 10)
+            where TReturn : class
         {
             efGraphQlService.AddNavigationConnectionField(this, name, resolve, graphType, arguments, includeNames, pageSize);
         }
@@ -49,16 +50,15 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected void AddQueryConnectionField<TGraph, TReturn>(
+        protected void AddQueryConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, graphType, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -91,7 +91,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField<TSource, TGraph, TReturn>(this, name, resolve, arguments);
+            return efGraphQlService.AddQueryField(this, typeof(TGraph), name, resolve, arguments);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -16,15 +16,15 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected void AddNavigationConnectionField<TGraph, TReturn>(string name,
+        protected void AddNavigationConnectionField<TReturn>(
+            string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
-            int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
+            int pageSize = 10) where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField(this, name, resolve,graphType, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
         protected void AddNavigationConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
@@ -31,7 +31,7 @@ namespace GraphQL.EntityFramework
         protected FieldType AddNavigationField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -42,7 +42,7 @@ namespace GraphQL.EntityFramework
         protected FieldType AddNavigationField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
@@ -53,7 +53,7 @@ namespace GraphQL.EntityFramework
         protected void AddQueryConnectionField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class
@@ -64,7 +64,7 @@ namespace GraphQL.EntityFramework
         protected FieldType AddQueryField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -29,17 +29,6 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType: typeof(TGraph));
-        }
-
         protected FieldType AddNavigationField<TReturn>(
             Type graphType,
             string name,

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -59,7 +59,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this,typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -29,17 +29,6 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType: typeof(TGraph));
-        }
-
         protected FieldType AddNavigationField<TReturn>(
             Type graphType,
             string name,
@@ -49,17 +38,6 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
-        }
-
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(this, typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -82,16 +60,6 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
-        }
-
-        protected FieldType AddQueryField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddQueryField(this, typeof(TGraph), name, resolve, arguments);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -29,25 +29,25 @@ namespace GraphQL.EntityFramework
         }
 
         protected FieldType AddNavigationField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name, resolve, graphType, arguments, includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name, resolve, graphType, arguments, includeNames);
         }
 
         protected void AddQueryConnectionField<TReturn>(
@@ -62,13 +62,13 @@ namespace GraphQL.EntityFramework
         }
 
         protected FieldType AddQueryField<TReturn>(
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField(this, graphType, name, resolve, arguments);
+            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments);
         }
     }
 }

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -37,7 +37,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType:typeof(TGraph));
+            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType: typeof(TGraph));
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -59,7 +59,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField(this,typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
+            return efGraphQlService.AddNavigationField(this, typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
@@ -17,8 +16,7 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TGraph, TReturn>(
-            string name,
+        protected void AddNavigationConnectionField<TGraph, TReturn>(string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
@@ -26,7 +24,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -51,7 +49,7 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TGraph, TReturn>(
+        protected void AddQueryConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -59,7 +57,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
@@ -16,7 +17,7 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected void AddNavigationConnectionField<TGraph, TReturn>(
+        protected ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -25,7 +26,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -50,7 +51,7 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected void AddQueryConnectionField<TGraph, TReturn>(
+        protected ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -58,7 +59,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -29,6 +29,17 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
+        protected FieldType AddNavigationField<TGraph, TReturn>(
+            string name,
+            Func<ResolveFieldContext<TSource>, TReturn> resolve,
+            IEnumerable<QueryArgument> arguments = null,
+            IEnumerable<string> includeNames = null)
+            where TGraph : ObjectGraphType<TReturn>
+            where TReturn : class
+        {
+            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType: typeof(TGraph));
+        }
+
         protected FieldType AddNavigationField<TReturn>(
             Type graphType,
             string name,
@@ -38,6 +49,17 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
+        }
+
+        protected FieldType AddNavigationField<TGraph, TReturn>(
+            string name,
+            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            IEnumerable<QueryArgument> arguments = null,
+            IEnumerable<string> includeNames = null)
+            where TGraph : ObjectGraphType<TReturn>
+            where TReturn : class
+        {
+            return efGraphQlService.AddNavigationField(this, typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -60,6 +82,16 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+        }
+
+        protected FieldType AddQueryField<TGraph, TReturn>(
+            string name,
+            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            IEnumerable<QueryArgument> arguments = null)
+            where TGraph : ObjectGraphType<TReturn>
+            where TReturn : class
+        {
+            return efGraphQlService.AddQueryField(this, typeof(TGraph), name, resolve, arguments);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -24,7 +24,7 @@ namespace GraphQL.EntityFramework
             IEnumerable<string> includeNames = null,
             int pageSize = 10) where TReturn : class
         {
-            efGraphQlService.AddNavigationConnectionField(this, name, resolve,graphType, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField(this, name, resolve, graphType, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -52,12 +52,13 @@ namespace GraphQL.EntityFramework
         protected void AddQueryConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, graphType, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -51,17 +51,6 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected FieldType AddNavigationField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddNavigationField(this, typeof(TGraph), name, resolve: resolve, arguments: arguments, includeNames: includeNames);
-        }
-
         protected FieldType AddNavigationField<TReturn>(
             Type graphType,
             string name,
@@ -82,16 +71,6 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
-        }
-
-        protected FieldType AddQueryField<TGraph, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>
-            where TReturn : class
-        {
-            return efGraphQlService.AddQueryField(this, typeof(TGraph), name, resolve, arguments);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
@@ -17,7 +16,7 @@ namespace GraphQL.EntityFramework
             this.efGraphQlService = efGraphQlService;
         }
 
-        protected ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TGraph, TReturn>(
+        protected void AddNavigationConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -26,7 +25,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
+            efGraphQlService.AddNavigationConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames, pageSize);
         }
 
         protected FieldType AddNavigationField<TReturn>(
@@ -51,7 +50,7 @@ namespace GraphQL.EntityFramework
             return efGraphQlService.AddNavigationField(this, graphType, name, resolve, arguments, includeNames);
         }
 
-        protected ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TGraph, TReturn>(
+        protected void AddQueryConnectionField<TGraph, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -59,7 +58,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField<TSource, TGraph, TReturn>(this, name, resolve, arguments, pageSize);
         }
 
         protected FieldType AddQueryField<TReturn>(

--- a/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
+++ b/src/GraphQL.EntityFramework/EfObjectGraphTypeT.cs
@@ -37,7 +37,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>
             where TReturn : class
         {
-            return efGraphQlService.AddNavigationField<TSource, TGraph, TReturn>(this, name, resolve, arguments, includeNames);
+            return efGraphQlService.AddNavigationField(this, name: name, resolve: resolve, arguments: arguments, includeNames: includeNames, graphType:typeof(TGraph));
         }
 
         protected FieldType AddNavigationField<TReturn>(

--- a/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
+++ b/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="ConfigureAwait.Fody" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="4.0.2" PrivateAssets="All" />
     <PackageReference Include="GraphQL" Version="2.4.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/src/GraphQL.EntityFramework/GraphTypeFinder.cs
+++ b/src/GraphQL.EntityFramework/GraphTypeFinder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using GraphQL.Utilities;
+
+static class GraphTypeFinder
+{
+    public static Type FindGraphType<TReturn>(Type graphType)
+        where TReturn : class
+    {
+        if (graphType != null)
+        {
+            return graphType;
+        }
+        graphType = GraphTypeTypeRegistry.Get<TReturn>();
+        if (graphType != null)
+        {
+            return graphType;
+        }
+        throw new Exception($"Could not resolve a GraphType for {nameof(TReturn)}. Either pass in a GraphType explicitly or register a GraphType using GraphTypeTypeRegistry.Register<{nameof(TReturn)},MyGraphType>().");
+
+    }
+}

--- a/src/GraphQL.EntityFramework/GraphTypeFinder.cs
+++ b/src/GraphQL.EntityFramework/GraphTypeFinder.cs
@@ -15,7 +15,7 @@ static class GraphTypeFinder
         {
             return graphType;
         }
-        throw new Exception($"Could not resolve a GraphType for {nameof(TReturn)}. Either pass in a GraphType explicitly or register a GraphType using GraphTypeTypeRegistry.Register<{nameof(TReturn)},MyGraphType>().");
+        throw new Exception($"Could not resolve a GraphType for {typeof(TReturn).FullName}. Either pass in a GraphType explicitly or register a GraphType using GraphTypeTypeRegistry.Register<{typeof(TReturn).FullName},MyGraphType>().");
 
     }
 }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -41,14 +41,5 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
-
-        FieldType AddNavigationField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -6,15 +6,6 @@ namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        FieldType AddNavigationField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
         FieldType AddNavigationField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             Type graphType,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -9,7 +9,7 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
@@ -17,7 +17,7 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
@@ -25,7 +25,7 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
@@ -33,7 +33,7 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -24,15 +24,6 @@ namespace GraphQL.EntityFramework
             IEnumerable<string> includeNames = null)
             where TReturn : class;
 
-        FieldType AddNavigationField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, TReturn> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
         FieldType AddNavigationField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -6,38 +6,34 @@ namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        FieldType AddNavigationField<TSource, TReturn>(
-            ObjectGraphType<TSource> graph,
-            Type graphType,
+        FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
 
-        FieldType AddNavigationField<TReturn>(
-            ObjectGraphType graph,
-            Type graphType,
+        FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, TReturn> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
 
-        FieldType AddNavigationField<TSource, TReturn>(
-            ObjectGraphType<TSource> graph,
-            Type graphType,
+        FieldType AddNavigationField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;
 
-        FieldType AddNavigationField<TReturn>(
-            ObjectGraphType graph,
-            Type graphType,
+        FieldType AddNavigationField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null)
             where TReturn : class;

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Navigation.cs
@@ -24,15 +24,6 @@ namespace GraphQL.EntityFramework
             IEnumerable<string> includeNames = null)
             where TReturn : class;
 
-        FieldType AddNavigationField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
         FieldType AddNavigationField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             Type graphType,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
-            ObjectGraphType graph,
+        void AddNavigationConnectionField<TGraph, TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -17,8 +15,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
+        void AddNavigationConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
@@ -6,22 +6,24 @@ namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        void AddNavigationConnectionField<TGraph, TReturn>(ObjectGraphType graph,
+        void AddNavigationConnectionField<TReturn>(
+            ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddNavigationConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
+        void AddNavigationConnectionField<TSource, TReturn>(
+            ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
+        void AddNavigationConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
@@ -17,7 +16,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
+        void AddNavigationConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
@@ -10,7 +10,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)
@@ -20,7 +20,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
             int pageSize = 10)

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_NavigationConnection.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        void AddNavigationConnectionField<TGraph, TReturn>(
+        ConnectionBuilder<TGraph, object> AddNavigationConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IEnumerable<TReturn>> resolve,
@@ -16,7 +17,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddNavigationConnectionField<TSource, TGraph, TReturn>(
+        ConnectionBuilder<TGraph, TSource> AddNavigationConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
@@ -9,25 +9,25 @@ namespace GraphQL.EntityFramework
     {
         FieldType AddQueryField<TReturn>(
             ObjectGraphType graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType graph,
-            Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
     }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
@@ -30,29 +30,5 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
-
-        FieldType AddQueryField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
-        FieldType AddQueryField<TSource, TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
-        FieldType AddQueryField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
@@ -27,7 +27,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
     }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Queryable.cs
@@ -11,7 +11,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        void AddQueryConnectionField<TGraph, TReturn>(
+        ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
@@ -16,7 +17,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -25,7 +26,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
+        void AddQueryConnectionField<TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
@@ -17,7 +16,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -26,7 +25,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -7,32 +7,29 @@ namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        void AddQueryConnectionField<TGraph, TReturn>(ObjectGraphType graph,
+        void AddQueryConnectionField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddQueryConnectionField<TSource, TGraph, TReturn>(
+        void AddQueryConnectionField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        void AddQueryConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
+        void AddQueryConnectionField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -10,7 +10,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class;
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class;
@@ -27,7 +27,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TSource, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TReturn : class;

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Builders;
 using GraphQL.Types;
 
 namespace GraphQL.EntityFramework
 {
     public partial interface IEfGraphQLService
     {
-        ConnectionBuilder<TGraph, object> AddQueryConnectionField<TGraph, TReturn>(
-            ObjectGraphType graph,
+        void AddQueryConnectionField<TGraph, TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,
@@ -17,7 +15,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
+        void AddQueryConnectionField<TSource, TGraph, TReturn>(
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
@@ -26,8 +24,7 @@ namespace GraphQL.EntityFramework
             where TGraph : ObjectGraphType<TReturn>, IGraphType
             where TReturn : class;
 
-        ConnectionBuilder<TGraph, TSource> AddQueryConnectionField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
+        void AddQueryConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null,

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_QueryableConnection.cs
@@ -10,6 +10,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TGraph, TReturn>(ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>, IGraphType
@@ -19,6 +20,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>, IGraphType
@@ -27,6 +29,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TSource, TGraph, TReturn>(ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null,
             int pageSize = 10)
             where TGraph : ObjectGraphType<TReturn>, IGraphType

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
@@ -10,24 +10,24 @@ namespace GraphQL.EntityFramework
         FieldType AddSingleField<TReturn>(
             ObjectGraphType graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
-            Type graphType,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
+            Type graphType,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
     }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
@@ -11,7 +11,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType<TSource> graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
 
@@ -27,7 +27,7 @@ namespace GraphQL.EntityFramework
             ObjectGraphType graph,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            Type graphType,
+            Type graphType = null,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
     }

--- a/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/IEfGraphQLService_Single.cs
@@ -30,29 +30,5 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments = null)
             where TReturn : class;
-
-        FieldType AddSingleField<TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
-        FieldType AddSingleField<TSource, TGraph, TReturn>(
-            ObjectGraphType graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
-
-        FieldType AddSingleField<TSource, TGraph, TReturn>(
-            ObjectGraphType<TSource> graph,
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments = null)
-            where TGraph : ObjectGraphType<TReturn>, IGraphType
-            where TReturn : class;
     }
 }

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -8,7 +8,8 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<EmployeeGraph, Employee>(
+        AddNavigationField(
+            typeof(EmployeeGraph),
             name: "employees",
             resolve: context => context.Source.Employees);
         AddNavigationConnectionField<EmployeeGraph, Employee>(

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -12,9 +12,10 @@ public class CompanyGraph :
             typeof(EmployeeGraph),
             name: "employees",
             resolve: context => context.Source.Employees);
-        AddNavigationConnectionField<EmployeeGraph, Employee>(
+        AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
+            typeof(EmployeeGraph),
             includeNames: new[] {"Employees"});
     }
 }

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -8,10 +8,8 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<Employee>(
-            typeof(EmployeeGraph),
-            name: "employees",
-            resolve: context => context.Source.Employees);
+        AddNavigationField<Employee>(name: "employees",
+            resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
         AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -8,8 +8,7 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField(
-            typeof(EmployeeGraph),
+        AddNavigationField<EmployeeGraph, Employee>(
             name: "employees",
             resolve: context => context.Source.Employees);
         AddNavigationConnectionField<EmployeeGraph, Employee>(

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -8,7 +8,8 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<EmployeeGraph, Employee>(
+        AddNavigationField<Employee>(
+            typeof(EmployeeGraph),
             name: "employees",
             resolve: context => context.Source.Employees);
         AddNavigationConnectionField<EmployeeGraph, Employee>(

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -8,12 +8,12 @@ public class CompanyGraph :
     {
         Field(x => x.Id);
         Field(x => x.Content);
-        AddNavigationField<Employee>(name: "employees",
-            resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
+        AddNavigationField<Employee>(
+            name: "employees",
+            resolve: context => context.Source.Employees);
         AddNavigationConnectionField(
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
-            typeof(EmployeeGraph),
             includeNames: new[] {"Employees"});
     }
 }

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -9,8 +9,7 @@ public class EmployeeGraph :
         Field(x => x.Id);
         Field(x => x.Content);
         Field(x => x.Age);
-        AddNavigationField(
-            typeof(CompanyGraph),
+        AddNavigationField<CompanyGraph, Company>(
             name: "company",
             resolve: context => context.Source.Company);
     }

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -9,9 +9,7 @@ public class EmployeeGraph :
         Field(x => x.Id);
         Field(x => x.Content);
         Field(x => x.Age);
-        AddNavigationField(
-            typeof(CompanyGraph),
-            name: "company",
-            resolve: context => context.Source.Company);
+        AddNavigationField(name: "company",
+            resolve: context => context.Source.Company, graphType: typeof(CompanyGraph));
     }
 }

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -9,7 +9,8 @@ public class EmployeeGraph :
         Field(x => x.Id);
         Field(x => x.Content);
         Field(x => x.Age);
-        AddNavigationField<CompanyGraph, Company>(
+        AddNavigationField(
+            typeof(CompanyGraph),
             name: "company",
             resolve: context => context.Source.Company);
     }

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -9,7 +9,8 @@ public class EmployeeGraph :
         Field(x => x.Id);
         Field(x => x.Content);
         Field(x => x.Age);
-        AddNavigationField(name: "company",
-            resolve: context => context.Source.Company, graphType: typeof(CompanyGraph));
+        AddNavigationField(
+            name: "company",
+            resolve: context => context.Source.Company);
     }
 }

--- a/src/SampleWeb/Graphs/EmployeeSummary.cs
+++ b/src/SampleWeb/Graphs/EmployeeSummary.cs
@@ -1,0 +1,5 @@
+public class EmployeeSummary
+{
+    public int CompanyId { get; set; }
+    public double AverageAge { get; set; }
+}

--- a/src/SampleWeb/Graphs/EmployeeSummaryGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeSummaryGraph.cs
@@ -10,9 +10,3 @@ public class EmployeeSummaryGraph :
         Field(x => x.AverageAge);
     }
 }
-
-public class EmployeeSummary
-{
-    public int CompanyId { get; set; }
-    public double AverageAge { get; set; }
-}

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -37,7 +37,8 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            });
+            },
+            graphType:typeof(CompanyGraph));
 
         AddQueryField(
             typeof(EmployeeGraph),
@@ -65,7 +66,8 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees;
-            });
+            },
+            graphType:typeof(EmployeeGraph));
         #region ManuallyApplyWhere
         Field<ListGraphType<EmployeeSummaryGraph>>(
             name: "employeeSummary",

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -11,20 +11,22 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(name: "companies",
+        AddQueryField(
+            name: "companies",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            }, graphType: typeof(CompanyGraph));
+            });
 
         #endregion
 
-        AddSingleField(resolve: context =>
+        AddSingleField(
+            resolve: context =>
         {
             var dataContext = (MyDataContext) context.UserContext;
             return dataContext.Companies;
-        }, graphType: typeof(CompanyGraph), name: "company");
+        }, name: "company");
 
         AddQueryConnectionField(
             name: "companiesConnection",
@@ -32,23 +34,25 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            },
-            graphType: typeof(CompanyGraph));
+            });
 
-        AddQueryField(name: "employees",
+        AddQueryField(
+            name: "employees",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees;
-            }, graphType: typeof(EmployeeGraph));
+            });
 
-        AddQueryField(name: "employeesByArgument",
+        AddQueryField(
+            name: "employeesByArgument",
             resolve: context =>
             {
                 var content = context.GetArgument<string>("content");
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees.Where(x => x.Content == content);
-            }, graphType: typeof(EmployeeGraph), arguments: new QueryArguments(new QueryArgument<StringGraphType> {Name = "content"}));
+            },
+            arguments: new QueryArguments(new QueryArgument<StringGraphType> {Name = "content"}));
 
         AddQueryConnectionField(
             name: "employeesConnection",
@@ -56,8 +60,7 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees;
-            },
-            graphType: typeof(EmployeeGraph));
+            });
 
         #region ManuallyApplyWhere
 

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -22,14 +22,11 @@ public class Query :
 
         #endregion
 
-        AddSingleField(
-            typeof(CompanyGraph),
-            name: "company",
-            resolve: context =>
-            {
-                var dataContext = (MyDataContext) context.UserContext;
-                return dataContext.Companies;
-            });
+        AddSingleField(resolve: context =>
+        {
+            var dataContext = (MyDataContext) context.UserContext;
+            return dataContext.Companies;
+        }, graphType: typeof(CompanyGraph), name: "company");
 
         AddQueryConnectionField(
             name: "companiesConnection",

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -11,14 +11,12 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(
-            typeof(CompanyGraph),
-            name: "companies",
+        AddQueryField(name: "companies",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
-            });
+            }, graphType: typeof(CompanyGraph));
 
         #endregion
 
@@ -37,25 +35,20 @@ public class Query :
             },
             graphType: typeof(CompanyGraph));
 
-        AddQueryField(
-            typeof(EmployeeGraph),
-            name: "employees",
+        AddQueryField(name: "employees",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees;
-            });
+            }, graphType: typeof(EmployeeGraph));
 
-        AddQueryField(
-            typeof(EmployeeGraph),
-            name: "employeesByArgument",
-            arguments: new QueryArguments(new QueryArgument<StringGraphType> {Name = "content"}),
+        AddQueryField(name: "employeesByArgument",
             resolve: context =>
             {
                 var content = context.GetArgument<string>("content");
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees.Where(x => x.Content == content);
-            });
+            }, graphType: typeof(EmployeeGraph), arguments: new QueryArguments(new QueryArgument<StringGraphType> {Name = "content"}));
 
         AddQueryConnectionField(
             name: "employeesConnection",

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -11,7 +11,8 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField<CompanyGraph, Company>(
+        AddQueryField(
+            typeof(CompanyGraph),
             name: "companies",
             resolve: context =>
             {
@@ -21,7 +22,8 @@ public class Query :
 
         #endregion
 
-        AddSingleField<CompanyGraph, Company>(
+        AddSingleField(
+            typeof(CompanyGraph),
             name: "company",
             resolve: context =>
             {
@@ -37,7 +39,8 @@ public class Query :
                 return dataContext.Companies;
             });
 
-        AddQueryField<EmployeeGraph, Employee>(
+        AddQueryField(
+            typeof(EmployeeGraph),
             name: "employees",
             resolve: context =>
             {
@@ -45,7 +48,8 @@ public class Query :
                 return dataContext.Employees;
             });
 
-        AddQueryField<EmployeeGraph, Employee>(
+        AddQueryField(
+            typeof(EmployeeGraph),
             name: "employeesByArgument",
             arguments: new QueryArguments(new QueryArgument<StringGraphType> {Name = "content"}),
             resolve: context =>

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -31,14 +31,14 @@ public class Query :
                 return dataContext.Companies;
             });
 
-        AddQueryConnectionField<CompanyGraph, Company>(
+        AddQueryConnectionField(
             name: "companiesConnection",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Companies;
             },
-            graphType:typeof(CompanyGraph));
+            graphType: typeof(CompanyGraph));
 
         AddQueryField(
             typeof(EmployeeGraph),
@@ -60,15 +60,17 @@ public class Query :
                 return dataContext.Employees.Where(x => x.Content == content);
             });
 
-        AddQueryConnectionField<EmployeeGraph, Employee>(
+        AddQueryConnectionField(
             name: "employeesConnection",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Employees;
             },
-            graphType:typeof(EmployeeGraph));
+            graphType: typeof(EmployeeGraph));
+
         #region ManuallyApplyWhere
+
         Field<ListGraphType<EmployeeSummaryGraph>>(
             name: "employeeSummary",
             arguments: new QueryArguments(
@@ -98,6 +100,7 @@ public class Query :
                         AverageAge = g.Average(x => x.Age),
                     };
             });
+
         #endregion
     }
 }

--- a/src/SampleWeb/Startup.cs
+++ b/src/SampleWeb/Startup.cs
@@ -6,6 +6,7 @@ using GraphQL.EntityFramework;
 using GraphQL;
 using GraphQL.Server;
 using GraphQL.Types;
+using GraphQL.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +15,10 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        GraphTypeTypeRegistry.Register<Employee, EmployeeGraph>();
+        GraphTypeTypeRegistry.Register<EmployeeSummary, EmployeeSummaryGraph>();
+        GraphTypeTypeRegistry.Register<Company, CompanyGraph>();
+
         services.AddScoped(provider => DataContextBuilder.BuildDataContext());
 
         EfGraphQLConventions.RegisterInContainer(services, DataContextBuilder.Model);

--- a/src/Snippets/ConnectionRootQuery.cs
+++ b/src/Snippets/ConnectionRootQuery.cs
@@ -17,7 +17,8 @@ class ConnectionRootQuery
                 {
                     var dataContext = (MyDataContext) context.UserContext;
                     return dataContext.Companies;
-                });
+                },
+                graphType:typeof(CompanyGraph));
         }
     }
 

--- a/src/Snippets/ConnectionRootQuery.cs
+++ b/src/Snippets/ConnectionRootQuery.cs
@@ -17,8 +17,7 @@ class ConnectionRootQuery
                 {
                     var dataContext = (MyDataContext) context.UserContext;
                     return dataContext.Companies;
-                },
-                graphType: typeof(CompanyGraph));
+                });
         }
     }
 

--- a/src/Snippets/ConnectionRootQuery.cs
+++ b/src/Snippets/ConnectionRootQuery.cs
@@ -11,14 +11,14 @@ class ConnectionRootQuery
         public Query(IEfGraphQLService graphQlService) :
             base(graphQlService)
         {
-            AddQueryConnectionField<CompanyGraph, Company>(
+            AddQueryConnectionField(
                 name: "companies",
                 resolve: context =>
                 {
                     var dataContext = (MyDataContext) context.UserContext;
                     return dataContext.Companies;
                 },
-                graphType:typeof(CompanyGraph));
+                graphType: typeof(CompanyGraph));
         }
     }
 

--- a/src/Snippets/ConnectionTypedGraph.cs
+++ b/src/Snippets/ConnectionTypedGraph.cs
@@ -14,8 +14,7 @@ class ConnectionTypedGraph
         {
             AddNavigationConnectionField(
                 name: "employees",
-                resolve: context => context.Source.Employees,
-                typeof(EmployeeGraph));
+                resolve: context => context.Source.Employees);
         }
     }
 

--- a/src/Snippets/ConnectionTypedGraph.cs
+++ b/src/Snippets/ConnectionTypedGraph.cs
@@ -12,9 +12,10 @@ class ConnectionTypedGraph
         public CompanyGraph(IEfGraphQLService graphQlService) :
             base(graphQlService)
         {
-            AddNavigationConnectionField<EmployeeGraph, Employee>(
+            AddNavigationConnectionField(
                 name: "employees",
-                resolve: context => context.Source.Employees);
+                resolve: context => context.Source.Employees,
+                typeof(EmployeeGraph));
         }
     }
 

--- a/src/Snippets/RootQuery.cs
+++ b/src/Snippets/RootQuery.cs
@@ -15,14 +15,12 @@ class RootQuery
                 var dataContext = (DataContext) context.UserContext;
                 return dataContext.Companies;
             }, graphType: typeof(CompanyGraph), name: "company");
-            AddQueryField(
-                typeof(CompanyGraph),
-                name: "companies",
+            AddQueryField(name: "companies",
                 resolve: context =>
                 {
                     var dataContext = (DataContext) context.UserContext;
                     return dataContext.Companies;
-                });
+                }, graphType: typeof(CompanyGraph));
         }
     }
     #endregion

--- a/src/Snippets/RootQuery.cs
+++ b/src/Snippets/RootQuery.cs
@@ -10,14 +10,11 @@ class RootQuery
         public Query(IEfGraphQLService graphQlService) :
             base(graphQlService)
         {
-            AddSingleField(
-                typeof(CompanyGraph),
-                name: "company",
-                resolve: context =>
-                {
-                    var dataContext = (DataContext) context.UserContext;
-                    return dataContext.Companies;
-                });
+            AddSingleField(resolve: context =>
+            {
+                var dataContext = (DataContext) context.UserContext;
+                return dataContext.Companies;
+            }, graphType: typeof(CompanyGraph), name: "company");
             AddQueryField(
                 typeof(CompanyGraph),
                 name: "companies",

--- a/src/Snippets/RootQuery.cs
+++ b/src/Snippets/RootQuery.cs
@@ -10,14 +10,16 @@ class RootQuery
         public Query(IEfGraphQLService graphQlService) :
             base(graphQlService)
         {
-            AddSingleField<CompanyGraph, Company>(
+            AddSingleField(
+                typeof(CompanyGraph),
                 name: "company",
                 resolve: context =>
                 {
                     var dataContext = (DataContext) context.UserContext;
                     return dataContext.Companies;
                 });
-            AddQueryField<CompanyGraph, Company>(
+            AddQueryField(
+                typeof(CompanyGraph),
                 name: "companies",
                 resolve: context =>
                 {

--- a/src/Snippets/RootQuery.cs
+++ b/src/Snippets/RootQuery.cs
@@ -4,25 +4,30 @@ using GraphQL.EntityFramework;
 class RootQuery
 {
     #region rootQuery
+
     public class Query :
         EfObjectGraphType
     {
         public Query(IEfGraphQLService graphQlService) :
             base(graphQlService)
         {
-            AddSingleField(resolve: context =>
-            {
-                var dataContext = (DataContext) context.UserContext;
-                return dataContext.Companies;
-            }, graphType: typeof(CompanyGraph), name: "company");
-            AddQueryField(name: "companies",
+            AddSingleField(
                 resolve: context =>
                 {
                     var dataContext = (DataContext) context.UserContext;
                     return dataContext.Companies;
-                }, graphType: typeof(CompanyGraph));
+                },
+                name: "company");
+            AddQueryField(
+                name: "companies",
+                resolve: context =>
+                {
+                    var dataContext = (DataContext) context.UserContext;
+                    return dataContext.Companies;
+                });
         }
     }
+
     #endregion
 
     class DataContext

--- a/src/Snippets/TypedGraph.cs
+++ b/src/Snippets/TypedGraph.cs
@@ -14,10 +14,8 @@ public class TypedGraph
         {
             Field(x => x.Id);
             Field(x => x.Content);
-            AddNavigationField<Employee>(
-                typeof(EmployeeGraph),
-                name: "employees",
-                resolve: context => context.Source.Employees);
+            AddNavigationField<Employee>(name: "employees",
+                resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
             AddNavigationConnectionField(
                 name: "employeesConnection",
                 resolve: context => context.Source.Employees,

--- a/src/Snippets/TypedGraph.cs
+++ b/src/Snippets/TypedGraph.cs
@@ -18,9 +18,10 @@ public class TypedGraph
                 typeof(EmployeeGraph),
                 name: "employees",
                 resolve: context => context.Source.Employees);
-            AddNavigationConnectionField<EmployeeGraph, Employee>(
+            AddNavigationConnectionField(
                 name: "employeesConnection",
                 resolve: context => context.Source.Employees,
+                typeof(EmployeeGraph),
                 includeNames: new[] {"Employees"});
         }
     }

--- a/src/Snippets/TypedGraph.cs
+++ b/src/Snippets/TypedGraph.cs
@@ -14,8 +14,7 @@ public class TypedGraph
         {
             Field(x => x.Id);
             Field(x => x.Content);
-            AddNavigationField<Employee>(
-                typeof(EmployeeGraph),
+            AddNavigationField<EmployeeGraph, Employee>(
                 name: "employees",
                 resolve: context => context.Source.Employees);
             AddNavigationConnectionField<EmployeeGraph, Employee>(

--- a/src/Snippets/TypedGraph.cs
+++ b/src/Snippets/TypedGraph.cs
@@ -14,12 +14,12 @@ public class TypedGraph
         {
             Field(x => x.Id);
             Field(x => x.Content);
-            AddNavigationField<Employee>(name: "employees",
-                resolve: context => context.Source.Employees, graphType: typeof(EmployeeGraph));
+            AddNavigationField<Employee>(
+                name: "employees",
+                resolve: context => context.Source.Employees);
             AddNavigationConnectionField(
                 name: "employeesConnection",
                 resolve: context => context.Source.Employees,
-                typeof(EmployeeGraph),
                 includeNames: new[] {"Employees"});
         }
     }

--- a/src/Snippets/TypedGraph.cs
+++ b/src/Snippets/TypedGraph.cs
@@ -14,7 +14,8 @@ public class TypedGraph
         {
             Field(x => x.Id);
             Field(x => x.Content);
-            AddNavigationField<EmployeeGraph, Employee>(
+            AddNavigationField<Employee>(
+                typeof(EmployeeGraph),
                 name: "employees",
                 resolve: context => context.Source.Employees);
             AddNavigationConnectionField<EmployeeGraph, Employee>(

--- a/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
@@ -9,10 +9,12 @@ public class ChildGraph :
         Field(x => x.Id);
         Field(x => x.Property);
         Field(x => x.Nullable, true);
-        AddNavigationField<ParentGraph, ParentEntity>(
+        AddNavigationField(
+            typeof(ParentGraph),
             name: "parent",
             resolve: context => context.Source.Parent);
-        AddNavigationField<ParentGraph, ParentEntity>(
+        AddNavigationField(
+            typeof(ParentGraph),
             name: "parentAlias",
             resolve: context => context.Source.Parent,
             includeNames: new []{"Parent"});

--- a/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
@@ -9,14 +9,10 @@ public class ChildGraph :
         Field(x => x.Id);
         Field(x => x.Property);
         Field(x => x.Nullable, true);
-        AddNavigationField(
-            typeof(ParentGraph),
-            name: "parent",
-            resolve: context => context.Source.Parent);
-        AddNavigationField(
-            typeof(ParentGraph),
-            name: "parentAlias",
+        AddNavigationField(name: "parent",
+            resolve: context => context.Source.Parent, graphType: typeof(ParentGraph));
+        AddNavigationField(name: "parentAlias",
             resolve: context => context.Source.Parent,
-            includeNames: new []{"Parent"});
+            graphType: typeof(ParentGraph), includeNames: new []{"Parent"});
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ChildGraph.cs
@@ -9,12 +9,10 @@ public class ChildGraph :
         Field(x => x.Id);
         Field(x => x.Property);
         Field(x => x.Nullable, true);
-        AddNavigationField(
-            typeof(ParentGraph),
+        AddNavigationField<ParentGraph, ParentEntity>(
             name: "parent",
             resolve: context => context.Source.Parent);
-        AddNavigationField(
-            typeof(ParentGraph),
+        AddNavigationField<ParentGraph, ParentEntity>(
             name: "parentAlias",
             resolve: context => context.Source.Parent,
             includeNames: new []{"Parent"});

--- a/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
@@ -8,7 +8,8 @@ public class FilterParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<FilterChildGraph, FilterChildEntity>(
+        AddNavigationField<FilterChildEntity>(
+            typeof(FilterChildGraph),
             name: "children",
             resolve: context => context.Source.Children);
         AddNavigationConnectionField<FilterChildGraph, FilterChildEntity>(

--- a/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
@@ -12,9 +12,10 @@ public class FilterParentGraph :
             typeof(FilterChildGraph),
             name: "children",
             resolve: context => context.Source.Children);
-        AddNavigationConnectionField<FilterChildGraph, FilterChildEntity>(
+        AddNavigationConnectionField(
             name: "childrenConnection",
             resolve: context => context.Source.Children,
+            typeof(FilterChildGraph),
             includeNames: new[] {"Children"});
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
@@ -8,8 +8,7 @@ public class FilterParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<FilterChildEntity>(
-            typeof(FilterChildGraph),
+        AddNavigationField<FilterChildGraph, FilterChildEntity>(
             name: "children",
             resolve: context => context.Source.Children);
         AddNavigationConnectionField<FilterChildGraph, FilterChildEntity>(

--- a/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
@@ -8,12 +8,12 @@ public class FilterParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<FilterChildEntity>(name: "children",
-            resolve: context => context.Source.Children, graphType: typeof(FilterChildGraph));
+        AddNavigationField<FilterChildEntity>(
+            name: "children",
+            resolve: context => context.Source.Children);
         AddNavigationConnectionField(
             name: "childrenConnection",
             resolve: context => context.Source.Children,
-            typeof(FilterChildGraph),
             includeNames: new[] {"Children"});
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Filtering/FilterParentGraph.cs
@@ -8,10 +8,8 @@ public class FilterParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<FilterChildEntity>(
-            typeof(FilterChildGraph),
-            name: "children",
-            resolve: context => context.Source.Children);
+        AddNavigationField<FilterChildEntity>(name: "children",
+            resolve: context => context.Source.Children, graphType: typeof(FilterChildGraph));
         AddNavigationConnectionField(
             name: "childrenConnection",
             resolve: context => context.Source.Children,

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
@@ -7,7 +7,8 @@ public class Level1Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(name: "level2Entity",
-            resolve: context => context.Source.Level2Entity, graphType: typeof(Level2Graph));
+        AddNavigationField(
+            name: "level2Entity",
+            resolve: context => context.Source.Level2Entity);
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
@@ -7,9 +7,7 @@ public class Level1Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level2Graph),
-            name: "level2Entity",
-            resolve: context => context.Source.Level2Entity);
+        AddNavigationField(name: "level2Entity",
+            resolve: context => context.Source.Level2Entity, graphType: typeof(Level2Graph));
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
@@ -7,8 +7,7 @@ public class Level1Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level2Graph),
+        AddNavigationField<Level2Graph, Level2Entity>(
             name: "level2Entity",
             resolve: context => context.Source.Level2Entity);
     }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level1Graph.cs
@@ -7,7 +7,8 @@ public class Level1Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField<Level2Graph, Level2Entity>(
+        AddNavigationField(
+            typeof(Level2Graph),
             name: "level2Entity",
             resolve: context => context.Source.Level2Entity);
     }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
@@ -7,7 +7,8 @@ public class Level2Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(name: "level3Entity",
-            resolve: context => context.Source.Level3Entity, graphType: typeof(Level3Graph));
+        AddNavigationField(
+            name: "level3Entity",
+            resolve: context => context.Source.Level3Entity);
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
@@ -7,7 +7,8 @@ public class Level2Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField<Level3Graph, Level3Entity>(
+        AddNavigationField(
+            typeof(Level3Graph),
             name: "level3Entity",
             resolve: context => context.Source.Level3Entity);
     }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
@@ -7,8 +7,7 @@ public class Level2Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level3Graph),
+        AddNavigationField<Level3Graph, Level3Entity>(
             name: "level3Entity",
             resolve: context => context.Source.Level3Entity);
     }

--- a/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Levels/Level2Graph.cs
@@ -7,9 +7,7 @@ public class Level2Graph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level3Graph),
-            name: "level3Entity",
-            resolve: context => context.Source.Level3Entity);
+        AddNavigationField(name: "level3Entity",
+            resolve: context => context.Source.Level3Entity, graphType: typeof(Level3Graph));
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
@@ -7,9 +7,7 @@ public class WithMisNamedQueryChildGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(WithMisNamedQueryParentGraph),
-            name: "parent",
-            resolve: context => context.Source.Parent);
+        AddNavigationField(name: "parent",
+            resolve: context => context.Source.Parent, graphType: typeof(WithMisNamedQueryParentGraph));
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
@@ -7,7 +7,8 @@ public class WithMisNamedQueryChildGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(name: "parent",
-            resolve: context => context.Source.Parent, graphType: typeof(WithMisNamedQueryParentGraph));
+        AddNavigationField(
+            name: "parent",
+            resolve: context => context.Source.Parent);
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
@@ -7,8 +7,7 @@ public class WithMisNamedQueryChildGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(WithMisNamedQueryParentGraph),
+        AddNavigationField<WithMisNamedQueryParentGraph, WithMisNamedQueryParentEntity>(
             name: "parent",
             resolve: context => context.Source.Parent);
     }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryChildGraph.cs
@@ -7,7 +7,8 @@ public class WithMisNamedQueryChildGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField<WithMisNamedQueryParentGraph, WithMisNamedQueryParentEntity>(
+        AddNavigationField(
+            typeof(WithMisNamedQueryParentGraph),
             name: "parent",
             resolve: context => context.Source.Parent);
     }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
@@ -8,8 +8,7 @@ public class WithMisNamedQueryParentGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddQueryField(
-            typeof(WithMisNamedQueryChildGraph),
+        AddQueryField<WithMisNamedQueryChildGraph, WithMisNamedQueryChildEntity>(
             name: "misNamedChildren",
             resolve: context =>
             {

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
@@ -8,14 +8,12 @@ public class WithMisNamedQueryParentGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddQueryField(
-            typeof(WithMisNamedQueryChildGraph),
-            name: "misNamedChildren",
+        AddQueryField(name: "misNamedChildren",
             resolve: context =>
             {
                 var dataContext = (MyDataContext)context.UserContext;
                 var parentId = context.Source.Id;
                 return dataContext.WithMisNamedQueryChildEntities.Where(x=>x.ParentId == parentId);
-            });
+            }, graphType: typeof(WithMisNamedQueryChildGraph));
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
@@ -8,12 +8,14 @@ public class WithMisNamedQueryParentGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddQueryField(name: "misNamedChildren",
+        AddQueryField(
+            name: "misNamedChildren",
             resolve: context =>
             {
                 var dataContext = (MyDataContext)context.UserContext;
                 var parentId = context.Source.Id;
-                return dataContext.WithMisNamedQueryChildEntities.Where(x=>x.ParentId == parentId);
-            }, graphType: typeof(WithMisNamedQueryChildGraph));
+                return dataContext.WithMisNamedQueryChildEntities
+                    .Where(x=>x.ParentId == parentId);
+            });
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/MisNamed/WithMisNamedQueryParentGraph.cs
@@ -8,7 +8,8 @@ public class WithMisNamedQueryParentGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddQueryField<WithMisNamedQueryChildGraph, WithMisNamedQueryChildEntity>(
+        AddQueryField(
+            typeof(WithMisNamedQueryChildGraph),
             name: "misNamedChildren",
             resolve: context =>
             {

--- a/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
@@ -8,8 +8,7 @@ public class ParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField(
-            typeof(ChildGraph),
+        AddNavigationField<ChildGraph, ChildEntity>(
             name: "children",
             resolve: context => context.Source.Children);
         AddNavigationConnectionField<ChildGraph, ChildEntity>(

--- a/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
@@ -8,10 +8,8 @@ public class ParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<ChildEntity>(
-            typeof(ChildGraph),
-            name: "children",
-            resolve: context => context.Source.Children);
+        AddNavigationField<ChildEntity>(name: "children",
+            resolve: context => context.Source.Children, graphType: typeof(ChildGraph));
         AddNavigationConnectionField(
             name: "childrenConnection",
             resolve: context => context.Source.Children,

--- a/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
@@ -8,7 +8,8 @@ public class ParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<ChildGraph, ChildEntity>(
+        AddNavigationField<ChildEntity>(
+            typeof(ChildGraph),
             name: "children",
             resolve: context => context.Source.Children);
         AddNavigationConnectionField<ChildGraph, ChildEntity>(

--- a/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
@@ -12,9 +12,10 @@ public class ParentGraph :
             typeof(ChildGraph),
             name: "children",
             resolve: context => context.Source.Children);
-        AddNavigationConnectionField<ChildGraph, ChildEntity>(
+        AddNavigationConnectionField(
             name: "childrenConnection",
             resolve: context => context.Source.Children,
+            typeof(ChildGraph),
             includeNames: new[] { "Children"});
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraph.cs
@@ -8,7 +8,8 @@ public class ParentGraph :
     {
         Field(x => x.Id);
         Field(x => x.Property);
-        AddNavigationField<ChildGraph, ChildEntity>(
+        AddNavigationField(
+            typeof(ChildGraph),
             name: "children",
             resolve: context => context.Source.Children);
         AddNavigationConnectionField<ChildGraph, ChildEntity>(

--- a/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
@@ -7,7 +7,8 @@ public class SkipLevelGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField<Level3Graph, Level3Entity>(
+        AddNavigationField(
+            typeof(Level3Graph),
             name: "level3Entity",
             resolve: context => context.Source.Level2Entity.Level3Entity,
             includeNames: new[] { "Level2Entity.Level3Entity"});

--- a/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
@@ -7,10 +7,8 @@ public class SkipLevelGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level3Graph),
-            name: "level3Entity",
+        AddNavigationField(name: "level3Entity",
             resolve: context => context.Source.Level2Entity.Level3Entity,
-            includeNames: new[] { "Level2Entity.Level3Entity"});
+            graphType: typeof(Level3Graph), includeNames: new[] { "Level2Entity.Level3Entity"});
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/SkipLevelGraph.cs
@@ -7,8 +7,7 @@ public class SkipLevelGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Level3Graph),
+        AddNavigationField<Level3Graph, Level3Entity>(
             name: "level3Entity",
             resolve: context => context.Source.Level2Entity.Level3Entity,
             includeNames: new[] { "Level2Entity.Level3Entity"});

--- a/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
@@ -8,15 +8,12 @@ public class WithManyChildrenGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Child1Graph),
-            name: "child1",
-            includeNames: new []{ "Child2", "Child1" },
+        AddNavigationField(name: "child1",
             resolve: context =>
             {
                 Assert.NotNull(context.Source.Child2);
                 Assert.NotNull(context.Source.Child1);
                 return context.Source.Child1;
-            });
+            }, graphType: typeof(Child1Graph), includeNames: new []{ "Child2", "Child1" });
     }
 }

--- a/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
@@ -8,7 +8,8 @@ public class WithManyChildrenGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField<Child1Graph, Child1Entity>(
+        AddNavigationField(
+            typeof(Child1Graph),
             name: "child1",
             includeNames: new []{ "Child2", "Child1" },
             resolve: context =>

--- a/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/WithManyChildrenGraph.cs
@@ -8,8 +8,7 @@ public class WithManyChildrenGraph :
         base(graphQlService)
     {
         Field(x => x.Id);
-        AddNavigationField(
-            typeof(Child1Graph),
+        AddNavigationField<Child1Graph, Child1Entity>(
             name: "child1",
             includeNames: new []{ "Child2", "Child1" },
             resolve: context =>

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.EntityFramework;
 using GraphQL.Types;
+using GraphQL.Utilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,6 +18,20 @@ public partial class IntegrationTests :
 {
     static IntegrationTests()
     {
+        GraphTypeTypeRegistry.Register<FilterChildEntity, FilterChildGraph>();
+        GraphTypeTypeRegistry.Register<FilterParentEntity, FilterParentGraph>();
+        GraphTypeTypeRegistry.Register<WithManyChildrenEntity, WithManyChildrenGraph>();
+        GraphTypeTypeRegistry.Register<CustomTypeEntity, CustomTypeGraph>();
+        GraphTypeTypeRegistry.Register<Child1Entity, Child1Graph>();
+        GraphTypeTypeRegistry.Register<ChildEntity, ChildGraph>();
+        GraphTypeTypeRegistry.Register<ParentEntity, ParentGraph>();
+        GraphTypeTypeRegistry.Register<Level1Entity, Level1Graph>();
+        GraphTypeTypeRegistry.Register<Level2Entity, Level2Graph>();
+        GraphTypeTypeRegistry.Register<Level3Entity, Level3Graph>();
+        GraphTypeTypeRegistry.Register<WithMisNamedQueryParentEntity, WithMisNamedQueryParentGraph>();
+        GraphTypeTypeRegistry.Register<WithNullableEntity, WithNullableGraph>();
+        GraphTypeTypeRegistry.Register<WithMisNamedQueryChildEntity, WithMisNamedQueryChildGraph>();
+
         using (var dataContext = BuildDataContext())
         {
             dataContext.Database.EnsureCreated();

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -6,107 +6,117 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(name: "customType",
+        AddQueryField(
+            name: "customType",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.CustomTypeEntities;
-            }, graphType: typeof(CustomTypeGraph));
+            });
 
-        AddQueryField(name: "skipLevel",
+        AddQueryField(
+            name: "skipLevel",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Level1Entities;
             }, graphType: typeof(SkipLevelGraph));
 
-        AddQueryField(name: "manyChildren",
+        AddQueryField(
+            name: "manyChildren",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithManyChildrenEntities;
-            }, graphType: typeof(WithManyChildrenGraph));
+            });
 
-        AddQueryField(name: "level1Entities",
+        AddQueryField(
+            name: "level1Entities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Level1Entities;
             }, graphType: typeof(Level1Graph));
 
-        efGraphQlService.AddQueryField(this,
+        efGraphQlService.AddQueryField(
+            this,
             name: "withNullableEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithNullableEntities;
-            }, graphType: typeof(WithNullableGraph));
+            });
 
-        efGraphQlService.AddQueryField(this,
+        efGraphQlService.AddQueryField(
+            this,
             name: "misNamed",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithMisNamedQueryParentEntities;
-            }, graphType: typeof(WithMisNamedQueryParentGraph));
+            });
 
-        efGraphQlService.AddQueryField(this,
+        efGraphQlService.AddQueryField(
+            this,
             name: "parentEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            }, graphType: typeof(ParentGraph));
+            });
 
-        efGraphQlService.AddQueryField(this,
+        efGraphQlService.AddQueryField(
+            this,
             name: "childEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ChildEntities;
-            }, graphType: typeof(ChildGraph));
+            });
 
-        efGraphQlService.AddQueryConnectionField<ParentGraph, ParentEntity>(this,
+        efGraphQlService.AddQueryConnectionField<ParentGraph, ParentEntity>(
+            this,
             name: "parentEntitiesConnection",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            },
-            graphType: typeof(ParentGraph));
+            });
 
-        efGraphQlService.AddQueryConnectionField<ChildGraph, ChildEntity>(this,
+        efGraphQlService.AddQueryConnectionField<ChildGraph, ChildEntity>(
+            this,
             name: "childEntitiesConnection",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ChildEntities;
-            },
-            graphType: typeof(ChildGraph));
+            });
 
-        efGraphQlService.AddQueryField(this,
+        efGraphQlService.AddQueryField(
+            this,
             name: "parentEntitiesFiltered",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.FilterParentEntities;
-            }, graphType: typeof(FilterParentGraph));
+            });
 
-        efGraphQlService.AddQueryConnectionField<FilterParentGraph, FilterParentEntity>(this,
+        efGraphQlService.AddQueryConnectionField<FilterParentGraph, FilterParentEntity>(
+            this,
             name: "parentEntitiesConnectionFiltered",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.FilterParentEntities;
-            },
-            graphType: typeof(FilterParentGraph));
+            });
 
-        efGraphQlService.AddSingleField(this,
+        efGraphQlService.AddSingleField(
+            this,
             name: "parentEntity",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            }, graphType: typeof(ParentGraph));
+            });
     }
 }

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -24,7 +24,7 @@ public class Query :
                 return dataContext.Level1Entities;
             });
 
-        AddQueryField<WithManyChildrenGraph, WithManyChildrenEntity>(
+        AddQueryField(typeof(WithManyChildrenGraph),
             name: "manyChildren",
             resolve: context =>
             {

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -42,40 +42,36 @@ public class Query :
             });
 
         efGraphQlService.AddQueryField(this,
-            typeof(WithNullableGraph),
             name: "withNullableEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithNullableEntities;
-            });
+            }, graphType: typeof(WithNullableGraph));
 
         efGraphQlService.AddQueryField(this,
-            typeof(WithMisNamedQueryParentGraph),
             name: "misNamed",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithMisNamedQueryParentEntities;
-            });
+            }, graphType: typeof(WithMisNamedQueryParentGraph));
 
         efGraphQlService.AddQueryField(this,
-            typeof(ParentGraph),
             name: "parentEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            });
+            }, graphType: typeof(ParentGraph));
 
         efGraphQlService.AddQueryField(this,
-            typeof(ChildGraph),
             name: "childEntities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ChildEntities;
-            });
+            }, graphType: typeof(ChildGraph));
 
         efGraphQlService.AddQueryConnectionField<ParentGraph, ParentEntity>(this,
             name: "parentEntitiesConnection",
@@ -96,13 +92,12 @@ public class Query :
             graphType: typeof(ChildGraph));
 
         efGraphQlService.AddQueryField(this,
-            typeof(FilterParentGraph),
             name: "parentEntitiesFiltered",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.FilterParentEntities;
-            });
+            }, graphType: typeof(FilterParentGraph));
 
         efGraphQlService.AddQueryConnectionField<FilterParentGraph, FilterParentEntity>(this,
             name: "parentEntitiesConnectionFiltered",
@@ -115,12 +110,10 @@ public class Query :
 
         efGraphQlService.AddSingleField(this,
             name: "parentEntity",
-            typeof(ParentGraph),
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            }
-        );
+            }, graphType: typeof(ParentGraph));
     }
 }

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -83,7 +83,8 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ParentEntities;
-            });
+            },
+            graphType: typeof(ParentGraph));
 
         efGraphQlService.AddQueryConnectionField<ChildGraph, ChildEntity>(this,
             name: "childEntitiesConnection",
@@ -91,14 +92,15 @@ public class Query :
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.ChildEntities;
-            });
+            },
+            graphType: typeof(ChildGraph));
 
         efGraphQlService.AddQueryField(this,
             typeof(FilterParentGraph),
             name: "parentEntitiesFiltered",
             resolve: context =>
             {
-                var dataContext = (MyDataContext)context.UserContext;
+                var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.FilterParentEntities;
             });
 
@@ -106,9 +108,10 @@ public class Query :
             name: "parentEntitiesConnectionFiltered",
             resolve: context =>
             {
-                var dataContext = (MyDataContext)context.UserContext;
+                var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.FilterParentEntities;
-            });
+            },
+            graphType: typeof(FilterParentGraph));
 
         efGraphQlService.AddSingleField(this,
             name: "parentEntity",

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -6,40 +6,33 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField(
-            typeof(CustomTypeGraph),
-            name: "customType",
+        AddQueryField(name: "customType",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.CustomTypeEntities;
-            });
+            }, graphType: typeof(CustomTypeGraph));
 
-        AddQueryField(
-            typeof(SkipLevelGraph),
-            name: "skipLevel",
+        AddQueryField(name: "skipLevel",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Level1Entities;
-            });
+            }, graphType: typeof(SkipLevelGraph));
 
-        AddQueryField(typeof(WithManyChildrenGraph),
-            name: "manyChildren",
+        AddQueryField(name: "manyChildren",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.WithManyChildrenEntities;
-            });
+            }, graphType: typeof(WithManyChildrenGraph));
 
-        AddQueryField(
-            typeof(Level1Graph),
-            name: "level1Entities",
+        AddQueryField(name: "level1Entities",
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;
                 return dataContext.Level1Entities;
-            });
+            }, graphType: typeof(Level1Graph));
 
         efGraphQlService.AddQueryField(this,
             name: "withNullableEntities",

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -6,7 +6,8 @@ public class Query :
     public Query(IEfGraphQLService efGraphQlService) :
         base(efGraphQlService)
     {
-        AddQueryField<CustomTypeGraph, CustomTypeEntity>(
+        AddQueryField(
+            typeof(CustomTypeGraph),
             name: "customType",
             resolve: context =>
             {
@@ -14,7 +15,8 @@ public class Query :
                 return dataContext.CustomTypeEntities;
             });
 
-        AddQueryField<SkipLevelGraph, Level1Entity>(
+        AddQueryField(
+            typeof(SkipLevelGraph),
             name: "skipLevel",
             resolve: context =>
             {
@@ -30,7 +32,8 @@ public class Query :
                 return dataContext.WithManyChildrenEntities;
             });
 
-        AddQueryField<Level1Graph, Level1Entity>(
+        AddQueryField(
+            typeof(Level1Graph),
             name: "level1Entities",
             resolve: context =>
             {
@@ -38,7 +41,8 @@ public class Query :
                 return dataContext.Level1Entities;
             });
 
-        efGraphQlService.AddQueryField<WithNullableGraph, WithNullableEntity>(this,
+        efGraphQlService.AddQueryField(this,
+            typeof(WithNullableGraph),
             name: "withNullableEntities",
             resolve: context =>
             {
@@ -46,7 +50,8 @@ public class Query :
                 return dataContext.WithNullableEntities;
             });
 
-        efGraphQlService.AddQueryField<WithMisNamedQueryParentGraph, WithMisNamedQueryParentEntity>(this,
+        efGraphQlService.AddQueryField(this,
+            typeof(WithMisNamedQueryParentGraph),
             name: "misNamed",
             resolve: context =>
             {
@@ -54,7 +59,8 @@ public class Query :
                 return dataContext.WithMisNamedQueryParentEntities;
             });
 
-        efGraphQlService.AddQueryField<ParentGraph, ParentEntity>(this,
+        efGraphQlService.AddQueryField(this,
+            typeof(ParentGraph),
             name: "parentEntities",
             resolve: context =>
             {
@@ -62,7 +68,8 @@ public class Query :
                 return dataContext.ParentEntities;
             });
 
-        efGraphQlService.AddQueryField<ChildGraph, ChildEntity>(this,
+        efGraphQlService.AddQueryField(this,
+            typeof(ChildGraph),
             name: "childEntities",
             resolve: context =>
             {
@@ -86,7 +93,8 @@ public class Query :
                 return dataContext.ChildEntities;
             });
 
-        efGraphQlService.AddQueryField<FilterParentGraph, FilterParentEntity>(this,
+        efGraphQlService.AddQueryField(this,
+            typeof(FilterParentGraph),
             name: "parentEntitiesFiltered",
             resolve: context =>
             {
@@ -102,8 +110,9 @@ public class Query :
                 return dataContext.FilterParentEntities;
             });
 
-        efGraphQlService.AddSingleField<ParentGraph, ParentEntity>(this,
+        efGraphQlService.AddSingleField(this,
             name: "parentEntity",
+            typeof(ParentGraph),
             resolve: context =>
             {
                 var dataContext = (MyDataContext) context.UserContext;

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>


### PR DESCRIPTION
 * GraphType is no longer a generic on any methods. instead it is passed as an optional `Type` parameter.
 * to define a default GraphType, register it at startup using `GraphTypeTypeRegistry.Register<Company, CompanyGraph>();`