### PR TITLE
Enable custom "primary key" field name for "id" and "ids", also switch id/ids to IdGraphType instead of StringGraphType (enables number and/or string IDs)

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
@@ -9,9 +9,12 @@ namespace GraphQL.EntityFramework
     {
         GlobalFilters filters;
 
+        internal IModel Model { get; }
+
         public EfGraphQLService(IModel model, GlobalFilters filters)
         {
             Guard.AgainstNull(nameof(model), model);
+            Model = model;
             this.filters = filters;
             includeAppender = new IncludeAppender(NavigationReader.GetNavigationProperties(model));
         }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
@@ -9,12 +9,9 @@ namespace GraphQL.EntityFramework
     {
         GlobalFilters filters;
 
-        internal IModel Model { get; }
-
         public EfGraphQLService(IModel model, GlobalFilters filters)
         {
             Guard.AgainstNull(nameof(model), model);
-            Model = model;
             this.filters = filters;
             includeAppender = new IncludeAppender(NavigationReader.GetNavigationProperties(model));
         }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -16,11 +16,12 @@ namespace GraphQL.EntityFramework
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, graphType);
+            var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, graphType, primaryKeyName);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
@@ -30,7 +31,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<string> includeName,
             int pageSize,
-            Type graphType)
+            Type graphType,
+            string primaryKeyName)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
@@ -45,7 +47,7 @@ namespace GraphQL.EntityFramework
             builder.ResolveAsync(async context =>
             {
                 var enumerable = resolve(context);
-                enumerable = enumerable.ApplyGraphQlArguments(context);
+                enumerable = enumerable.ApplyGraphQlArguments(context, primaryKeyName);
                 enumerable = await filters.ApplyFilter(enumerable, context.UserContext);
                 var page = enumerable.ToList();
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
@@ -13,11 +13,12 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
+            IEnumerable<string> includeNames = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildNavigationField(graphType, name, resolve, includeNames, arguments);
+            var field = BuildNavigationField(graphType, name, resolve, includeNames, arguments, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -26,12 +27,13 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<string> includeNames,
-            IEnumerable<QueryArgument> arguments)
+            IEnumerable<QueryArgument> arguments,
+            string primaryKeyName)
             where TReturn : class
         {
             graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
             var listGraphType = MakeListGraphType(graphType);
-            return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
+            return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments, primaryKeyName);
         }
 
         FieldType BuildNavigationField<TSource, TReturn>(
@@ -39,7 +41,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             IEnumerable<string> includeNames,
             Type listGraphType,
-            IEnumerable<QueryArgument> arguments)
+            IEnumerable<QueryArgument> arguments,
+            string primaryKeyName)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
@@ -54,7 +57,7 @@ namespace GraphQL.EntityFramework
                     context =>
                     {
                         var result = resolve(context);
-                        result = result.ApplyGraphQlArguments(context);
+                        result = result.ApplyGraphQlArguments(context, primaryKeyName);
                         return filters.ApplyFilter(result, context.UserContext);
                     })
             };

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
@@ -14,11 +14,12 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField(graphType, name, resolve, arguments);
+            var field = BuildQueryField(graphType, name, resolve, arguments, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -27,11 +28,12 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField(graphType, name, resolve, arguments);
+            var field = BuildQueryField(graphType, name, resolve, arguments, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -40,11 +42,12 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildQueryField(graphType, name, resolve, arguments);
+            var field = BuildQueryField(graphType, name, resolve, arguments, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -52,17 +55,19 @@ namespace GraphQL.EntityFramework
             Type graphType,
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments)
+            IEnumerable<QueryArgument> arguments,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
-            return BuildQueryField(name, resolve, arguments, graphType);
+            return BuildQueryField(name, resolve, arguments, graphType, primaryKeyName);
         }
 
         FieldType BuildQueryField<TSource, TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             IEnumerable<QueryArgument> arguments,
-            Type graphType)
+            Type graphType,
+            string primaryKeyName)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
@@ -79,7 +84,7 @@ namespace GraphQL.EntityFramework
                     {
                         var returnTypes = resolve(context);
                         var withIncludes = includeAppender.AddIncludes(returnTypes, context);
-                        var withArguments = withIncludes.ApplyGraphQlArguments(context);
+                        var withArguments = withIncludes.ApplyGraphQlArguments(context, primaryKeyName);
                         var list = await withArguments.ToListAsync(context.CancellationToken);
                         return await filters.ApplyFilter(list, context.UserContext);
                     })

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
@@ -14,11 +14,12 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildQueryConnectionField(name, resolve, pageSize,graphType);
+            var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType, primaryKeyName);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
@@ -29,11 +30,12 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType);
+            var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType, primaryKeyName);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
@@ -44,11 +46,12 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType);
+            var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType, primaryKeyName);
             var field = graph.AddField(connection.FieldType);
             field.AddWhereArgument(arguments);
         }
@@ -57,7 +60,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             int pageSize,
-            Type graphType)
+            Type graphType,
+            string primaryKeyName)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
@@ -74,7 +78,7 @@ namespace GraphQL.EntityFramework
                 context =>
                 {
                     var withIncludes = includeAppender.AddIncludes(resolve(context), context);
-                    var withArguments = withIncludes.ApplyGraphQlArguments(context);
+                    var withArguments = withIncludes.ApplyGraphQlArguments(context, primaryKeyName);
                     return withArguments
                         .ApplyConnectionContext(
                             context.First,

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
@@ -14,11 +14,12 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField(name, resolve, arguments, graphType);
+            var field = BuildSingleField(name, resolve, arguments, graphType, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -27,11 +28,12 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField(name, resolve, arguments, graphType);
+            var field = BuildSingleField(name, resolve, arguments, graphType, primaryKeyName);
             return graph.AddField(field);
         }
 
@@ -40,19 +42,16 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
-            var field = BuildSingleField(name, resolve, arguments, graphType);
+            var field = BuildSingleField(name, resolve, arguments, graphType, primaryKeyName);
             return graph.AddField(field);
         }
 
-        FieldType BuildSingleField<TSource, TReturn>(
-            string name,
-            Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
-            IEnumerable<QueryArgument> arguments,
-            Type graphType)
+        FieldType BuildSingleField<TSource, TReturn>(string name, Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve, IEnumerable<QueryArgument> arguments, Type graphType, string primaryKeyName)
             where TReturn : class
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
@@ -69,7 +68,7 @@ namespace GraphQL.EntityFramework
                     {
                         var returnTypes = resolve(context);
                         var withIncludes = includeAppender.AddIncludes(returnTypes, context);
-                        var withArguments = withIncludes.ApplyGraphQlArguments(context);
+                        var withArguments = withIncludes.ApplyGraphQlArguments(context, primaryKeyName);
 
                         var single = await withArguments.SingleOrDefaultAsync(context.CancellationToken);
                         if (await filters.ShouldInclude(context.UserContext, single))

--- a/src/GraphQL.EntityFramework/GraphApi/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfObjectGraphType.cs
@@ -54,20 +54,22 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize, primaryKeyName);
         }
 
         protected FieldType AddQueryField<TReturn>(
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments);
+            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments, primaryKeyName);
         }
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Navigation.cs
@@ -18,7 +18,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IEnumerable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            IEnumerable<string> includeNames = null)
+            IEnumerable<string> includeNames = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_NavigationConnection.cs
@@ -13,7 +13,8 @@ namespace GraphQL.EntityFramework
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
             IEnumerable<string> includeNames = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Queryable.cs
@@ -12,7 +12,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         FieldType AddQueryField<TSource, TReturn>(
@@ -20,7 +21,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         FieldType AddQueryField<TSource, TReturn>(
@@ -28,7 +30,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_QueryableConnection.cs
@@ -12,7 +12,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         void AddQueryConnectionField<TSource, TReturn>(
@@ -21,7 +22,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         void AddQueryConnectionField<TSource, TReturn>(ObjectGraphType<TSource> graph,
@@ -29,7 +31,8 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Single.cs
@@ -12,7 +12,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -20,7 +21,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -28,7 +30,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveFieldContext<TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
@@ -21,20 +21,22 @@ namespace GraphQL.EntityFramework
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             IEnumerable<QueryArgument> arguments = null,
-            int pageSize = 10)
+            int pageSize = 10,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
-            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize);
+            efGraphQlService.AddQueryConnectionField(this, name, resolve, graphType, arguments, pageSize, primaryKeyName);
         }
 
         protected FieldType AddQueryField<TReturn>(
             string name,
             Func<ResolveFieldContext<object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            string primaryKeyName = "Id")
             where TReturn : class
         {
-            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments);
+            return efGraphQlService.AddQueryField(this, name, resolve, graphType, arguments, primaryKeyName);
         }
 
         protected FieldType AddSingleField<TReturn>(

--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
@@ -7,18 +7,18 @@ namespace GraphQL.EntityFramework
 {
   public  static partial class ArgumentProcessor
     {
-        public static IEnumerable<TItem> ApplyGraphQlArguments<TItem, TSource>(this IEnumerable<TItem> items, ResolveFieldContext<TSource> context)
+        public static IEnumerable<TItem> ApplyGraphQlArguments<TItem, TSource>(this IEnumerable<TItem> items, ResolveFieldContext<TSource> context, string primaryKeyName = "Id")
         {
             Guard.AgainstNull(nameof(items),items);
             Guard.AgainstNull(nameof(context),context);
-            return ApplyToAll(items, (type, x) => context.GetArgument(type, x));
+            return ApplyToAll(items, (type, x) => context.GetArgument(type, x), primaryKeyName);
         }
 
-        static IEnumerable<TItem> ApplyToAll<TItem>(this IEnumerable<TItem> items, Func<Type, string, object> getArguments)
+        static IEnumerable<TItem> ApplyToAll<TItem>(this IEnumerable<TItem> items, Func<Type, string, object> getArguments, string primaryKeyName)
         {
             if (ArgumentReader.TryReadIds(getArguments, out var values))
             {
-                var predicate = FuncBuilder<TItem>.BuildPredicate("Id", Comparison.In, values);
+                var predicate = FuncBuilder<TItem>.BuildPredicate(primaryKeyName, Comparison.In, values);
                 items = items.Where(predicate);
             }
 

--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_Queryable.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_Queryable.cs
@@ -6,24 +6,24 @@ namespace GraphQL.EntityFramework
 {
     public static partial class ArgumentProcessor
     {
-        public static IQueryable<TItem> ApplyGraphQlArguments<TItem, TSource>(this IQueryable<TItem> queryable, ResolveFieldContext<TSource> context)
+        public static IQueryable<TItem> ApplyGraphQlArguments<TItem, TSource>(this IQueryable<TItem> queryable, ResolveFieldContext<TSource> context, string primaryKeyName = "Id")
         {
             Guard.AgainstNull(nameof(queryable),queryable);
             Guard.AgainstNull(nameof(context),context);
-            return ApplyToAll(queryable, (type, x) => context.GetArgument(type, x));
+            return ApplyToAll(queryable, (type, x) => context.GetArgument(type, x), primaryKeyName);
         }
 
-        static IQueryable<TItem> ApplyToAll<TItem>(this IQueryable<TItem> queryable, Func<Type, string, object> getArguments)
+        static IQueryable<TItem> ApplyToAll<TItem>(this IQueryable<TItem> queryable, Func<Type, string, object> getArguments, string primaryKeyName)
         {
             if (ArgumentReader.TryReadIds(getArguments, out var values))
             {
-                var predicate = ExpressionBuilder<TItem>.BuildPredicate("Id", Comparison.In, values);
+                var predicate = ExpressionBuilder<TItem>.BuildPredicate(primaryKeyName, Comparison.In, values);
                 queryable = queryable.Where(predicate);
             }
 
             if (ArgumentReader.TryReadId(getArguments, out var value))
             {
-                var predicate = ExpressionBuilder<TItem>.BuildSinglePredicate("Id", Comparison.Equal, value);
+                var predicate = ExpressionBuilder<TItem>.BuildSinglePredicate(primaryKeyName, Comparison.Equal, value);
                 queryable = queryable.Where(predicate);
             }
 

--- a/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
@@ -29,6 +29,8 @@ static class ArgumentReader
 
         if (argument is List<object> lo)
             expression = lo.Select(o => o.ToString()).ToArray();
+        else if (argument is object[] oa)
+            expression = oa.Select(o => o.ToString()).ToArray();
         else
             throw new InvalidOperationException($"TryReadIds got an 'ids' argument of type '{argument.GetType().FullName}' which is unhandled.");
 

--- a/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
@@ -27,12 +27,8 @@ static class ArgumentReader
             return false;
         }
 
-        if (argument is int[] ia)
-            expression = ia.Select(i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
-        else if (argument is long[] la)
-            expression = la.Select(i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
-        else if (argument is string[] sa)
-            expression = sa;
+        if (argument is List<object> lo)
+            expression = lo.Select(o => o.ToString()).ToArray();
         else
             throw new InvalidOperationException($"TryReadIds got an 'ids' argument of type '{argument.GetType().FullName}' which is unhandled.");
 
@@ -41,23 +37,23 @@ static class ArgumentReader
 
     public static bool TryReadId(Func<Type, string, object> getArgument, out string expression)
     {
-            var argument = getArgument(typeof(object), "id");
-            if (argument == null)
-            {
-                expression = null;
-                return false;
-            }
+        var argument = getArgument(typeof(object), "id");
+        if (argument == null)
+        {
+            expression = null;
+            return false;
+        }
 
-            if (argument is int i)
-                expression = i.ToString(CultureInfo.InvariantCulture);
-            else if (argument is long l)
-                expression = l.ToString(CultureInfo.InvariantCulture);
-            else if (argument is string s)
-                expression = s;
-            else
-                throw new InvalidOperationException($"TryReadId got an 'id' argument of type '{argument.GetType().FullName}' which is unhandled.");
-            
-            return true;
+        if (argument is long l)
+            expression = l.ToString(CultureInfo.InvariantCulture);
+        else if (argument is int i)
+            expression = i.ToString(CultureInfo.InvariantCulture);
+        else if (argument is string s)
+            expression = s;
+        else
+            throw new InvalidOperationException($"TryReadId got an 'id' argument of type '{argument.GetType().FullName}' which is unhandled.");
+
+        return true;
     }
 
 

--- a/src/GraphQL.EntityFramework/Where/ArgumentsAppender.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentsAppender.cs
@@ -20,17 +20,17 @@ static class ArgumentAppender
         };
     }
 
-    static QueryArgument<ListGraphType<StringGraphType>> idsArgument()
+    static QueryArgument<ListGraphType<IdGraphType>> idsArgument()
     {
-        return new QueryArgument<ListGraphType<StringGraphType>>
+        return new QueryArgument<ListGraphType<IdGraphType>>
         {
             Name = "ids"
         };
     }
 
-    static QueryArgument<StringGraphType> idArgument()
+    static QueryArgument<IdGraphType> idArgument()
     {
-        return new QueryArgument<StringGraphType>
+        return new QueryArgument<IdGraphType>
         {
             Name = "id"
         };

--- a/src/SampleWeb.Tests/GraphQlControllerTests.cs
+++ b/src/SampleWeb.Tests/GraphQlControllerTests.cs
@@ -147,6 +147,39 @@ query {
     }
 
     [Fact]
+    public async Task Get_employee_by_id()
+    {
+        var query = @"
+query {
+  employees(id: 2) {
+    employeeId
+    companyId
+    age
+  }
+}";
+        var response = await ClientQueryExecutor.ExecuteGet(client, query);
+        response.EnsureSuccessStatusCode();
+        var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+        var expected = JObject.FromObject(new
+        {
+            data = new
+            {
+                employees = new[]
+                {
+                    new
+                    {
+                        employeeId = 2,
+                        companyId = 1,
+                        age = 25
+                    }
+                }
+            }
+        });
+        Assert.Equal(expected.ToString(), result.ToString());
+    }
+
+    [Fact]
     public async Task Post()
     {
         var query = @"

--- a/src/SampleWeb.Tests/GraphQlControllerTests.cs
+++ b/src/SampleWeb.Tests/GraphQlControllerTests.cs
@@ -50,7 +50,7 @@ public class GraphQlControllerTests :
     public async Task Get_single()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   company(id:$id)
   {
@@ -72,7 +72,7 @@ query ($id: String!)
     public async Task Get_variable()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   companies(ids:[$id])
   {
@@ -146,17 +146,13 @@ query {
         Assert.Equal(expected.ToString(), result.ToString());
     }
 
-    [Fact]
-    public async Task Get_employee_by_id()
+    [Theory]
+    [InlineData("query { employees(id: 2) { employeeId age content } }")]
+    [InlineData("query { employees(id: \"2\") { employeeId age content } }")]
+    [InlineData("query { employees(ids: [2]) { employeeId age content } }")]
+    [InlineData("query { employees(ids: [\"2\"]) { employeeId age content } }")]
+    public async Task Get_employee_by_id(string query)
     {
-        var query = @"
-query {
-  employees(id: 2) {
-    employeeId
-    companyId
-    age
-  }
-}";
         var response = await ClientQueryExecutor.ExecuteGet(client, query);
         response.EnsureSuccessStatusCode();
         var result = JObject.Parse(await response.Content.ReadAsStringAsync());
@@ -170,8 +166,8 @@ query {
                     new
                     {
                         employeeId = 2,
-                        companyId = 1,
-                        age = 25
+                        age = 25,
+                        content = "Employee1"
                     }
                 }
             }
@@ -201,7 +197,7 @@ query {
     public async Task Post_variable()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   companies(ids:[$id])
   {

--- a/src/SampleWeb/DataContext/Employee.cs
+++ b/src/SampleWeb/DataContext/Employee.cs
@@ -1,6 +1,6 @@
 ﻿public class Employee
 {
-    public int Id { get; set; }
+    public int EmployeeId { get; set; }
     public int CompanyId { get; set; }
     public Company Company { get; set; }
     public string Content { get; set; }

--- a/src/SampleWeb/DbContextBuilder.cs
+++ b/src/SampleWeb/DbContextBuilder.cs
@@ -24,14 +24,14 @@ static class DbContextBuilder
         };
         var employee1 = new Employee
         {
-            Id = 2,
+            EmployeeId = 2,
             CompanyId = company1.Id,
             Content = "Employee1",
             Age = 25
         };
         var employee2 = new Employee
         {
-            Id = 3,
+            EmployeeId = 3,
             CompanyId = company1.Id,
             Content = "Employee2",
             Age = 31 
@@ -43,7 +43,7 @@ static class DbContextBuilder
         };
         var employee4 = new Employee
         {
-            Id = 5,
+            EmployeeId = 5,
             CompanyId = company2.Id,
             Content = "Employee4",
             Age = 34 

--- a/src/SampleWeb/Graphs/EmployeeGraph.cs
+++ b/src/SampleWeb/Graphs/EmployeeGraph.cs
@@ -6,7 +6,7 @@ public class EmployeeGraph :
     public EmployeeGraph(IEfGraphQLService graphQlService) :
         base(graphQlService)
     {
-        Field(x => x.Id);
+        Field(x => x.EmployeeId);
         Field(x => x.Content);
         Field(x => x.Age);
         AddNavigationField(

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -43,7 +43,8 @@ public class Query :
             {
                 var dbContext = (MyDbContext) context.UserContext;
                 return dbContext.Employees;
-            });
+            },
+            primaryKeyName: nameof(Employee.EmployeeId));
 
         AddQueryField(
             name: "employeesByArgument",
@@ -57,7 +58,8 @@ public class Query :
                 new QueryArgument<StringGraphType>
                 {
                     Name = "content"
-                }));
+                }),
+            primaryKeyName: nameof(Employee.EmployeeId));
 
         AddQueryConnectionField(
             name: "employeesConnection",
@@ -65,7 +67,8 @@ public class Query :
             {
                 var dbContext = (MyDbContext) context.UserContext;
                 return dbContext.Employees;
-            });
+            },
+            primaryKeyName: nameof(Employee.EmployeeId));
 
         #region ManuallyApplyWhere
 


### PR DESCRIPTION
#### Description

Enables the ability to use a custom EF property for primary keys (rather than hard-coded "Id"). This allows us to "out of the box" support basically any comparison property for the built in "id" and "ids" arguments on queries.

Also changes id/ids to IdGraphType to give the ability to take said id(s) in either numeric, or string format.

#### The solution

Pretty much just add "primaryKeyName" to the relevant functions, in place of "Id" inside of the two ArgumentProcessor parts.

As for enabling "IdGraphType" for the id(s) fields, just making a simple change in ArgumentsAppender, and some other changes for TryReadId(s) to get the argument as a straight object, and do a manual type conversion to string(s) where required.

Relevant tests have been added for custom primary key names. (Not integration tests, as they cannot be run currently)

#### ToDo

Possibly we should take an Expression as the "primary key" instead of a string? This would follow the "fluent" mentality.

This is potentially a breaking change (most likely will be) due to the IdGraphType change. May be worth splitting this PR into two if required. 