### PR TITLE
Change "id" and "ids" to accept IdGraphType instead of only String

### DIFF
--- a/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using GraphQL.EntityFramework;
 
@@ -17,28 +18,44 @@ static class ArgumentReader
 
     public static bool TryReadIds(Func<Type, string, object> getArgument, out string[] expression)
     {
-        var argument = (string[])getArgument(typeof(string[]), "ids");
+        var argument = getArgument(typeof(object), "ids");
         if (argument == null)
         {
             expression = null;
             return false;
         }
 
-        expression = argument;
+        if (argument is IEnumerable<object> objCollection)
+            expression = objCollection.Select(o => o.ToString()).ToArray();
+        else
+            throw new InvalidOperationException($"TryReadIds got an 'ids' argument of type '{argument.GetType().FullName}' which is unhandled.");
 
         return true;
     }
 
     public static bool TryReadId(Func<Type, string, object> getArgument, out string expression)
     {
-        var argument = (string)getArgument(typeof(string), "id");
+        var argument = getArgument(typeof(object), "id");
         if (argument == null)
         {
             expression = null;
             return false;
         }
 
-        expression = argument;
+        switch (argument)
+        {
+            case long l:   
+                expression = l.ToString(CultureInfo.InvariantCulture);
+                break;
+            case int i:    
+                expression = i.ToString(CultureInfo.InvariantCulture);
+                break;
+            case string s: 
+                expression = s;
+                break;
+            default:       
+                throw new InvalidOperationException($"TryReadId got an 'id' argument of type '{argument.GetType().FullName}' which is unhandled.");
+        }
 
         return true;
     }

--- a/src/GraphQL.EntityFramework/Where/ArgumentsAppender.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentsAppender.cs
@@ -20,17 +20,17 @@ static class ArgumentAppender
         };
     }
 
-    static QueryArgument<ListGraphType<StringGraphType>> idsArgument()
+    static QueryArgument<ListGraphType<IdGraphType>> idsArgument()
     {
-        return new QueryArgument<ListGraphType<StringGraphType>>
+        return new QueryArgument<ListGraphType<IdGraphType>>
         {
             Name = "ids"
         };
     }
 
-    static QueryArgument<StringGraphType> idArgument()
+    static QueryArgument<IdGraphType> idArgument()
     {
-        return new QueryArgument<StringGraphType>
+        return new QueryArgument<IdGraphType>
         {
             Name = "id"
         };

--- a/src/SampleWeb.Tests/GraphQlControllerTests.cs
+++ b/src/SampleWeb.Tests/GraphQlControllerTests.cs
@@ -50,7 +50,7 @@ public class GraphQlControllerTests :
     public async Task Get_single()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   company(id:$id)
   {
@@ -72,7 +72,7 @@ query ($id: String!)
     public async Task Get_variable()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   companies(ids:[$id])
   {
@@ -168,7 +168,7 @@ query {
     public async Task Post_variable()
     {
         var query = @"
-query ($id: String!)
+query ($id: ID!)
 {
   companies(ids:[$id])
   {


### PR DESCRIPTION
#### Description

Allow the use of "number" based Ids in the "id" and "ids" variables for Query fields.

This is a semi-breaking change, depending on query usage.