### PR TITLE
Boolean lists

### DIFF
--- a/src/GraphQL.EntityFramework/Where/ReflectionCache.cs
+++ b/src/GraphQL.EntityFramework/Where/ReflectionCache.cs
@@ -11,6 +11,8 @@ static class ReflectionCache
     static MethodInfo guidNullableListContains;
     static MethodInfo intListContains;
     static MethodInfo intNullableListContains;
+    static MethodInfo boolListContains;
+    static MethodInfo boolNullableListContains;
     static MethodInfo shortListContains;
     static MethodInfo shortNullableListContains;
     static MethodInfo longListContains;
@@ -42,6 +44,8 @@ static class ReflectionCache
             .MakeGenericMethod(typeof(string));
         guidListContains = GetContains<Guid>();
         guidNullableListContains = GetContains<Guid?>();
+        boolListContains = GetContains<bool>();
+        boolNullableListContains = GetContains<bool?>();
         intListContains = GetContains<int>();
         intNullableListContains = GetContains<int?>();
         shortListContains = GetContains<short>();
@@ -53,8 +57,8 @@ static class ReflectionCache
         ushortListContains = GetContains<ushort>();
         ushortNullableListContains = GetContains<ushort?>();
         ulongListContains = GetContains<ulong>();
-        ulongNullableListContains = GetContains<ushort?>();
-        dateTimeListContains = GetContains<ulong>();
+        ulongNullableListContains = GetContains<ulong?>();
+        dateTimeListContains = GetContains<DateTime>();
         dateTimeNullableListContains = GetContains<DateTime?>();
         dateTimeOffsetListContains = GetContains<DateTimeOffset>();
         dateTimeOffsetNullableListContains = GetContains<DateTimeOffset?>();
@@ -69,6 +73,15 @@ static class ReflectionCache
         if (type == typeof(Guid?))
         {
             return guidNullableListContains;
+        }
+
+        if (type == typeof(bool))
+        {
+            return boolListContains;
+        }
+        if (type == typeof(bool?))
+        {
+            return boolNullableListContains;
         }
 
         if (type == typeof(int))

--- a/src/Tests/TypeConverterTests.cs
+++ b/src/Tests/TypeConverterTests.cs
@@ -76,12 +76,16 @@ public class TypeConverterTests :
     {
         var result = TypeConverter.ConvertStringsToList(values, type);
         Assert.Equal(values.Length, result.Count);
-        for(var i = 0; i< values.Length; i++)
+        for (var i = 0; i < values.Length; i++)
         {
             var actual = result[i] is DateTime || result[i] is DateTimeOffset
                 ? string.Format("{0:yyyy-MM-dd H:mm}", result[i])
                 : Convert.ToString(result[i]);
             Assert.Equal(expected?[i] ?? values[i], actual, ignoreCase: true);
+
+            var convertType = type.IsGenericType ? type.GenericTypeArguments[0] : type;
+            var contains = (bool)ReflectionCache.GetListContains(type).Invoke(result, new[] { Convert.ChangeType(result[0], convertType) });
+            Assert.True(contains);
         }
     }
 


### PR DESCRIPTION
This is a followup to #164.

I've added tests for executing the Contains method, which revealed the need to add support for booleans, and revealed a bug for `ulong?` and `DateTime` lists.

I experimented with converting these static fields to a dictionary to ensure integrity in the future, but wasn't sure.  Something like this:

```cs
    private static Dictionary<Type, MethodInfo> containsCache = new Dictionary<Type, MethodInfo>();

    static ReflectionCache()
    {
        ...

        AddContainsMethod<Guid>();
        AddContainsMethod<bool>();
        AddContainsMethod<int>();
        AddContainsMethod<short>();
        AddContainsMethod<long>();
        AddContainsMethod<uint>();
        AddContainsMethod<ushort>();
        AddContainsMethod<ulong>();
        AddContainsMethod<DateTime>();
        AddContainsMethod<DateTimeOffset>();
    }

    private static void AddContainsMethod<T>() where T : struct
    {
        containsCache.Add(typeof(T), GetContains<T>());
        containsCache.Add(typeof(T?), GetContains<T?>());
    }

    public static MethodInfo GetListContains(Type type) => 
        // this call is thread-safe as long as nothing adds to the dictionary
        containsCache.TryGetValue(type, out var method) ? method : null;
```   
