### PR TITLE
Add 'arguments' parameter to QueryGraphType.AddSingleField

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
@@ -42,10 +42,11 @@ namespace GraphQL.EntityFramework
         protected FieldType AddSingleField<TReturn>(
             Func<ResolveEfFieldContext<TDbContext, object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            string name = nameof(TReturn))
+            string name = nameof(TReturn),
+            IEnumerable<QueryArgument> arguments = null)
             where TReturn : class
         {
-            return efGraphQlService.AddSingleField(this, name, resolve, graphType);
+            return efGraphQlService.AddSingleField(this, name, resolve, graphType, arguments);
         }
     }
 }


### PR DESCRIPTION
#### Description

The arguments parameter was missing from QueryGraphType.AddSingleField.  The parameter already exists on IEfGraphQlService.AddSingleField, and the former method is just an alias for it.  So it appears to be an unintentional omission.


#### The solution

Add the missing parameter


#### Related issue

See #168 
