### PR TITLE
Add comments to source code

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -38,19 +38,31 @@ namespace GraphQL.EntityFramework
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
             Guard.AgainstNegative(nameof(pageSize), pageSize);
-            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
+
+            //lookup the graph type if not explicitly specified
+            graphType = graphType ?? GraphTypeFinder.FindGraphType<TReturn>();
+            //create a ConnectionBuilder<graphType, TSource> type by invoking the static Create method on the generic type
             var fieldType = GetFieldType<TSource>(name, graphType);
+            //create a ConnectionBuilder<FakeGraph, TSource> which will be returned from this method
             var builder = ConnectionBuilder<FakeGraph, TSource>.Create(name);
+            //set the page size
             builder.PageSize(pageSize);
+            //using reflection, override the private field type property of the ConnectionBuilder<FakeGraph, TSource> to be the ConnectionBuilder<graphType, TSource> object
             SetField(builder, fieldType);
+            //add the metadata for the tables to be included in the query to the ConnectionBuilder<graphType, TSource> object
             IncludeAppender.SetIncludeMetadata(builder.FieldType, name, includeName);
+            //set the custom resolver
             builder.ResolveAsync(async context =>
             {
+                //run the specified resolve function
                 var enumerable = resolve(BuildEfContextFromGraphQlContext(context));
+                //apply any query filters specified in the arguments
                 enumerable = enumerable.ApplyGraphQlArguments(context);
+                //apply the global filter on each individually enumerated item
                 enumerable = await filters.ApplyFilter(enumerable, context.UserContext);
+                //pagination does NOT occur server-side at this point, as the query has already executed
                 var page = enumerable.ToList();
-
+                //return the proper page of data
                 return ConnectionConverter.ApplyConnectionContext(
                     page,
                     context.First,
@@ -58,6 +70,8 @@ namespace GraphQL.EntityFramework
                     context.Last,
                     context.Before);
             });
+            
+            //return the field to be added to the graph
             return builder;
         }
 
@@ -70,7 +84,7 @@ namespace GraphQL.EntityFramework
         static object GetFieldType<TSource>(string name, Type graphType)
         {
             var makeGenericType = typeof(ConnectionBuilder<,>).MakeGenericType(graphType, typeof(TSource));
-            dynamic x = makeGenericType.GetMethod("Create").Invoke(null, new object[] {name});
+            dynamic x = makeGenericType.GetMethod("Create").Invoke(null, new object[] { name });
             return x.FieldType;
         }
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -22,8 +22,11 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
+            //build the connection field
             var connection = BuildListConnectionField(name, resolve, includeNames, pageSize, graphType);
+            //add the field to the graph
             var field = graph.AddField(connection.FieldType);
+            //append the optional where arguments to the field
             field.AddWhereArgument(arguments);
         }
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
@@ -19,7 +19,11 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
+            //graphType should represent the graph type of the enumerated value, not the list graph type
+
+            //build the navigation field
             var field = BuildNavigationField(graphType, name, resolve, includeNames, arguments);
+            //add it to the graph
             return graph.AddField(field);
         }
 
@@ -31,8 +35,12 @@ namespace GraphQL.EntityFramework
             IEnumerable<QueryArgument> arguments)
             where TReturn : class
         {
-            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
+            //lookup the graph type if not explicitly specified
+            graphType = graphType ?? GraphTypeFinder.FindGraphType<TReturn>();
+            //graphType represents the base field type, not the list graph type
+            //create a list graph type based on the graph type specified
             var listGraphType = MakeListGraphType(graphType);
+            //build the navigation field
             return BuildNavigationField(name, resolve, includeNames, listGraphType, arguments);
         }
 
@@ -46,17 +54,25 @@ namespace GraphQL.EntityFramework
         {
             Guard.AgainstNullWhiteSpace(nameof(name), name);
             Guard.AgainstNull(nameof(resolve), resolve);
+
+            //return the new field type
             return new FieldType
             {
                 Name = name,
                 Type = listGraphType,
+                //take the arguments manually specified, if any, and append the query arguments
                 Arguments = ArgumentAppender.GetQueryArguments(arguments),
+                //add the metadata for the tables to be included in the query
                 Metadata = IncludeAppender.GetIncludeMetadata(name, includeNames),
+                //specify a custom resolve function
                 Resolver = new AsyncFieldResolver<TSource, IEnumerable<TReturn>>(
                     context =>
                     {
+                        //run the specified resolve function
                         var result = resolve(BuildEfContextFromGraphQlContext(context));
+                        //apply any query filters specified in the arguments
                         result = result.ApplyGraphQlArguments(context);
+                        //apply the global filter on each individually enumerated item
                         return filters.ApplyFilter(result, context.UserContext);
                     })
             };

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
@@ -20,8 +20,11 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
+            //build the connection field
             var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType);
+            //add the field to the graph
             var field = graph.AddField(connection.FieldType);
+            //append the optional where arguments to the field
             field.AddWhereArgument(arguments);
         }
 
@@ -35,8 +38,11 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
+            //build the connection field
             var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType);
+            //add the field to the graph
             var field = graph.AddField(connection.FieldType);
+            //append the optional where arguments to the field
             field.AddWhereArgument(arguments);
         }
 
@@ -50,8 +56,11 @@ namespace GraphQL.EntityFramework
             where TReturn : class
         {
             Guard.AgainstNull(nameof(graph), graph);
+            //build the connection field
             var connection = BuildQueryConnectionField(name, resolve, pageSize, graphType);
+            //add the field to the graph
             var field = graph.AddField(connection.FieldType);
+            //append the optional where arguments to the field
             field.AddWhereArgument(arguments);
         }
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
@@ -66,19 +66,30 @@ namespace GraphQL.EntityFramework
             Guard.AgainstNull(nameof(resolve), resolve);
             Guard.AgainstNegative(nameof(pageSize), pageSize);
 
-            graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);
+            //lookup the graph type if not explicitly specified
+            graphType = graphType ?? GraphTypeFinder.FindGraphType<TReturn>();
+            //create a ConnectionBuilder<graphType, TSource> type by invoking the static Create method on the generic type
             var fieldType = GetFieldType<TSource>(name, graphType);
+            //create a ConnectionBuilder<FakeGraph, TSource> which will be returned from this method
             var builder = ConnectionBuilder<FakeGraph, TSource>.Create(name);
+            //set the page size
             builder.PageSize(pageSize);
+            //using reflection, override the private field type property of the ConnectionBuilder<FakeGraph, TSource> to be the ConnectionBuilder<graphType, TSource> object
             SetField(builder, fieldType);
 
+            //set the resolve function (note: this is not async capable)
             builder.Resolve(
                 context =>
                 {
+                    //obtain the ef context
                     var efFieldContext = BuildEfContextFromGraphQlContext(context);
+                    //run the resolve function, then include the related tables on the returned query
                     var withIncludes = includeAppender.AddIncludes(resolve(efFieldContext), context);
+                    //get field names of the table's primary key(s)
                     var names = GetKeyNames<TReturn>();
+                    //apply any query filters specified in the arguments
                     var withArguments = withIncludes.ApplyGraphQlArguments(context, names);
+                    //apply skip/take to query as appropriate, and return the query
                     return withArguments
                         .ApplyConnectionContext(
                             context.First,
@@ -88,7 +99,10 @@ namespace GraphQL.EntityFramework
                             context,
                             context.CancellationToken,
                             filters);
+                    //note: does not apply global filters
                 });
+
+            //return the field to be added to the graph
             return builder;
         }
     }

--- a/src/GraphQL.EntityFramework/GraphTypeFinder.cs
+++ b/src/GraphQL.EntityFramework/GraphTypeFinder.cs
@@ -3,14 +3,10 @@ using GraphQL.Utilities;
 
 static class GraphTypeFinder
 {
-    public static Type FindGraphType<TReturn>(Type graphType)
+    public static Type FindGraphType<TReturn>()
         where TReturn : class
     {
-        if (graphType != null)
-        {
-            return graphType;
-        }
-        graphType = GraphTypeTypeRegistry.Get<TReturn>();
+        var graphType = GraphTypeTypeRegistry.Get<TReturn>();
         if (graphType != null)
         {
             return graphType;


### PR DESCRIPTION
I suggest comments be added to the code for readability.  Pull request attached with a bunch of comments added in a few key areas.  Only one other change for readability:

From:
graphType = GraphTypeFinder.FindGraphType<TReturn>(graphType);

To:
graphType = graphType ?? GraphTypeFinder.FindGraphType<TReturn>();

This change just makes it more obvious what the code is doing, as it is functionally identical.  The FindGraphType function is not public, so changing the signature is not a breaking change.

Patron under the name of Zbox.