### PR TITLE
Suggestion: Allow nullable AddSingleField queries

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Single.cs
@@ -13,7 +13,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
 
         FieldType AddSingleField<TReturn>(
@@ -21,7 +22,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, object>, Task<IQueryable<TReturn>>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -29,7 +31,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -37,7 +40,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, TSource>, Task<IQueryable<TReturn>>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -45,7 +49,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
 
         FieldType AddSingleField<TSource, TReturn>(
@@ -53,7 +58,8 @@ namespace GraphQL.EntityFramework
             string name,
             Func<ResolveEfFieldContext<TDbContext, TSource>, Task<IQueryable<TReturn>>> resolve,
             Type graphType = null,
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class;
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/QueryGraphType.cs
@@ -54,20 +54,22 @@ namespace GraphQL.EntityFramework
             Func<ResolveEfFieldContext<TDbContext, object>, IQueryable<TReturn>> resolve,
             Type graphType = null,
             string name = nameof(TReturn),
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class
         {
-            return efGraphQlService.AddSingleField(this, name, resolve, graphType, arguments);
+            return efGraphQlService.AddSingleField(this, name, resolve, graphType, arguments, nullable);
         }
 
         protected FieldType AddSingleField<TReturn>(
             Func<ResolveEfFieldContext<TDbContext, object>, Task<IQueryable<TReturn>>> resolve,
             Type graphType = null,
             string name = nameof(TReturn),
-            IEnumerable<QueryArgument> arguments = null)
+            IEnumerable<QueryArgument> arguments = null,
+            bool nullable = false)
             where TReturn : class
         {
-            return efGraphQlService.AddSingleField(this, name, resolve, graphType, arguments);
+            return efGraphQlService.AddSingleField(this, name, resolve, graphType, arguments, nullable);
         }
     }
 }

--- a/src/SampleWeb/Query.cs
+++ b/src/SampleWeb/Query.cs
@@ -21,6 +21,11 @@ public class Query :
             resolve: context => context.DbContext.Companies,
             name: "company");
 
+        AddSingleField(
+            resolve: context => context.DbContext.Companies,
+            name: "companyOrNull",
+            nullable: true);
+
         AddQueryConnectionField(
             name: "companiesConnection",
             resolve: context => context.DbContext.Companies);

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleNullable_Found.approved.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleNullable_Found.approved.txt
@@ -1,0 +1,5 @@
+﻿{
+  parentEntityNullable: {
+    property: 'Value1'
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleNullable_NotFound.approved.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleNullable_NotFound.approved.txt
@@ -1,0 +1,3 @@
+﻿{
+  parentEntityNullable: null
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_Found.approved.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_Found.approved.txt
@@ -1,0 +1,5 @@
+﻿{
+  parentEntity: {
+    property: 'Value1'
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -457,6 +457,74 @@ query ($value: String!)
     }
 
     [Fact]
+    public async Task Single_Found()
+    {
+        var query = @"
+{
+  parentEntity(id: ""00000000-0000-0000-0000-000000000001"") {
+    property
+  }
+}";
+        var entity1 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Property = "Value1"
+        };
+        var entity2 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            Property = "Value2"
+        };
+        using (var database = await sqlInstance.Build())
+        {
+            var result = await RunQuery(database, query, null, null, entity1, entity2);
+            ObjectApprover.Verify(result);
+        }
+    }
+
+    [Fact]
+    public async Task SingleNullable_NotFound()
+    {
+        var query = @"
+{
+  parentEntityNullable(id: ""00000000-0000-0000-0000-000000000001"") {
+    property
+  }
+}";
+        using (var database = await sqlInstance.Build())
+        {
+            var result = await RunQuery(database, query, null, null);
+            ObjectApprover.Verify(result);
+        }
+    }
+
+    [Fact]
+    public async Task SingleNullable_Found()
+    {
+        var query = @"
+{
+  parentEntityNullable(id: ""00000000-0000-0000-0000-000000000001"") {
+    property
+  }
+}";
+        var entity1 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Property = "Value1"
+        };
+        var entity2 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            Property = "Value2"
+        };
+        using (var database = await sqlInstance.Build())
+        {
+            var result = await RunQuery(database, query, null, null, entity1, entity2);
+            ObjectApprover.Verify(result);
+        }
+    }
+
+    [Fact]
     public async Task SingleParent_Child()
     {
         var query = @"

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -65,5 +65,10 @@ public class Query :
         AddSingleField(
             name: "parentEntity",
             resolve: context => context.DbContext.ParentEntities);
+
+        AddSingleField(
+            name: "parentEntityNullable",
+            resolve: context => context.DbContext.ParentEntities,
+            nullable: true);
     }
 }


### PR DESCRIPTION
I suggest that you allow AddSingleField nullable queries, where if there is no match in the database, null is returned in the graph.

This could be accomplished in two ways:
1) modify the signature of AddSingleField to add a nullable parameter, or
2) add additional methods called AddSingleOrDefaultField

The pull request utilizes the former, as it matches the Field signature provided by the underlying GraphQL framework, where nullable is a parameter (where the default is false)

I added another field in SampleWeb called 'companyOrNull' to test the feature via GraphiQL.

- Patron under name of Zbox