### PR TITLE
- Added ability to query list based navigation properties

### DIFF
--- a/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
+++ b/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Fody" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="ModuleInit.Fody" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="GraphQL" Version="2.4.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
     <PackageReference Include="ProjectDefaults" Version="1.0.24" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />

--- a/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
@@ -8,7 +8,7 @@ namespace GraphQL.EntityFramework
 {
     public static class ExpressionBuilder<T>
     {
-        private static readonly string LIST_PROPERTY_PATTERN = @"\[(.*)\]";
+        private const string LIST_PROPERTY_PATTERN = @"\[(.*)\]";
 
         public static Expression<Func<T, bool>> BuildPredicate(WhereExpression where)
         {
@@ -37,7 +37,8 @@ namespace GraphQL.EntityFramework
                 // Generate the predicate for the list item type
                 var subPredicate = typeof(ExpressionBuilder<>)
                     .MakeGenericType(listItemType)
-                    .GetMethod("BuildPredicate", BindingFlags.NonPublic | BindingFlags.Static)
+                    .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                    .Where(m => m.Name.Equals("BuildPredicate") && m.GetParameters().Length == 4).Single()
                     .Invoke(new object(), new object[] { listPath, comparison, values!, stringComparison! }) as Expression;
 
                 // Generate a method info for the Any Enumerable Static Method

--- a/src/Tests/ExpressionBuilderTests.cs
+++ b/src/Tests/ExpressionBuilderTests.cs
@@ -410,12 +410,12 @@ public class ExpressionBuilderTests :
 
     [Theory]
     [InlineData("Employees[Name]", Comparison.Equal, "Person 1", "Company 1", null)]
-    [InlineData("Employees[Name]", Comparison.NotEqual, "Person 3", "Company 2", null)]
+    [InlineData("Employees[Name]", Comparison.NotEqual, "Person 3", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.Contains, "son 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.StartsWith, "Person 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.EndsWith, "son 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.EndsWith, "person 2", "Company 1", StringComparison.OrdinalIgnoreCase)]
-    [InlineData("Employees[Age]", Comparison.Equal, "12", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.Equal, "12", "Company 1", null)]
     [InlineData("Employees[Age]", Comparison.GreaterThan, "12", "Company 2", null)]
     [InlineData("Employees[Age]", Comparison.NotEqual, "12", "Company 2", null)]
     [InlineData("Employees[Age]", Comparison.GreaterThanOrEqual, "31", "Company 2", null)]
@@ -461,7 +461,7 @@ public class ExpressionBuilderTests :
                     },
                     new Person
                     {
-                        Name = "Person 4",
+                        Name = "Person 3",
                         Age = 31,
                         DateOfBirth = new DateTime(1980, 10, 11, 10, 10, 10, DateTimeKind.Utc)
                     },

--- a/src/Tests/FuncBuilderTests.cs
+++ b/src/Tests/FuncBuilderTests.cs
@@ -322,10 +322,96 @@ public class FuncBuilderTests :
         Assert.Equal(expectedName, result.Name);
     }
 
+    [Theory]
+    [InlineData("Employees[Name]", Comparison.Equal, "Person 1", "Company 1", null)]
+    [InlineData("Employees[Name]", Comparison.NotEqual, "Person 3", "Company 2", null)]
+    [InlineData("Employees[Name]", Comparison.Contains, "son 2", "Company 1", null)]
+    [InlineData("Employees[Name]", Comparison.StartsWith, "Person 2", "Company 1", null)]
+    [InlineData("Employees[Name]", Comparison.EndsWith, "son 2", "Company 1", null)]
+    [InlineData("Employees[Name]", Comparison.EndsWith, "person 2", "Company 1", StringComparison.OrdinalIgnoreCase)]
+    [InlineData("Employees[Age]", Comparison.Equal, "12", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.GreaterThan, "12", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.NotEqual, "12", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.GreaterThanOrEqual, "31", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.LessThan, "13", "Company 1", null)]
+    [InlineData("Employees[Age]", Comparison.LessThanOrEqual, "12", "Company 1", null)]
+    [InlineData("Employees[DateOfBirth]", Comparison.Equal, "2001-10-10T10:10:10+00:00", "Company 1", null)]
+    [InlineData("Employees[DateOfBirth.Day]", Comparison.Equal, "11", "Company 2", null)]
+    [InlineData("Employees[Company.Employees[Name]]", Comparison.Contains, "son 2", "Company 1", null)]
+    public void ListMemberQueryCombos(string name, Comparison expression, string value, string expectedName, StringComparison? stringComparison)
+    {
+        var companies = new List<Company>
+        {
+            new Company
+            {
+                Name = "Company 1",
+                Employees = new List<Person>
+                {
+                    new Person
+                    {
+                        Name = "Person 1",
+                        Age = 12,
+                        DateOfBirth = new DateTime(1999, 10, 10, 10, 10, 10, DateTimeKind.Utc)
+                    },
+                    new Person
+                    {
+                        Name = "Person 2",
+                        Age = 12,
+                        DateOfBirth = new DateTime(2001, 10, 10, 10, 10, 10, DateTimeKind.Utc)
+                    }
+                }
+            },
+
+            new Company
+            {
+                Name = "Company 2",
+                Employees = new List<Person>
+                {
+                    new Person
+                    {
+                        Name = "Person 3",
+                        Age = 34,
+                        DateOfBirth = new DateTime(1977, 10, 11, 10, 10, 10, DateTimeKind.Utc)
+                    },
+                    new Person
+                    {
+                        Name = "Person 4",
+                        Age = 31,
+                        DateOfBirth = new DateTime(1980, 10, 11, 10, 10, 10, DateTimeKind.Utc)
+                    },
+                }
+            }
+        };
+
+        for (var i = 0; i < companies.Count(); i++)
+        {
+            var company = companies[i];
+
+            for (var j = 0; j < company.Employees.Count(); j++)
+            {
+                var employee = company.Employees[j];
+
+                employee.Company = company;
+            }
+        }
+
+        var result = companies
+            .Where(FuncBuilder<Company>.BuildPredicate(name, expression, new[] { value }, stringComparison))
+            .Single();
+        Assert.Equal(expectedName, result.Name);
+    }
+
+    public class Company
+    {
+        public string? Name { get; set; }
+        public List<Person> Employees { get; set; } = null!;
+    }
+
     public class Person
     {
         public string? Name { get; set; }
         public int Age { get; set; }
+        public Company? Company { get; set; }
         public DateTime DateOfBirth { get; set; }
     }
 

--- a/src/Tests/FuncBuilderTests.cs
+++ b/src/Tests/FuncBuilderTests.cs
@@ -324,12 +324,12 @@ public class FuncBuilderTests :
 
     [Theory]
     [InlineData("Employees[Name]", Comparison.Equal, "Person 1", "Company 1", null)]
-    [InlineData("Employees[Name]", Comparison.NotEqual, "Person 3", "Company 2", null)]
+    [InlineData("Employees[Name]", Comparison.NotEqual, "Person 3", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.Contains, "son 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.StartsWith, "Person 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.EndsWith, "son 2", "Company 1", null)]
     [InlineData("Employees[Name]", Comparison.EndsWith, "person 2", "Company 1", StringComparison.OrdinalIgnoreCase)]
-    [InlineData("Employees[Age]", Comparison.Equal, "12", "Company 2", null)]
+    [InlineData("Employees[Age]", Comparison.Equal, "12", "Company 1", null)]
     [InlineData("Employees[Age]", Comparison.GreaterThan, "12", "Company 2", null)]
     [InlineData("Employees[Age]", Comparison.NotEqual, "12", "Company 2", null)]
     [InlineData("Employees[Age]", Comparison.GreaterThanOrEqual, "31", "Company 2", null)]
@@ -375,7 +375,7 @@ public class FuncBuilderTests :
                     },
                     new Person
                     {
-                        Name = "Person 4",
+                        Name = "Person 3",
                         Age = 31,
                         DateOfBirth = new DateTime(1980, 10, 11, 10, 10, 10, DateTimeKind.Utc)
                     },


### PR DESCRIPTION
To access properties of list based navigation properties, the property should be encapsulated in bracket notation "[]". This works on connection queries as well.

E.g.
(where: {path: "employees[content]", comparison: "contains", value: "4"})

Or for more complex traversal:
(where: {path: "employees[company.employees[content]]", comparison: "contains", value: "4"})

I am not a patron, but expect I will create an open collective account on my own time, expect more PR's from me.