### PR TITLE
Add support to GraphQL fragments and interfaces

### DIFF
--- a/doco/configuration.md
+++ b/doco/configuration.md
@@ -22,10 +22,13 @@ To change this file edit the source file and then run MarkdownSnippets.
     * [ExecutionOptions](#executionoptions)
     * [Query](#query)
     * [GraphType](#graphtype)
-    * [InterfaceGraphType](#interfacegraphtype)
   * [Testing the GraphQlController](#testing-the-graphqlcontroller)
   * [GraphQlExtensions](#graphqlextensions)
-    * [ExecuteWithErrorCheck](#executewitherrorcheck)<!-- endtoc -->
+    * [ExecuteWithErrorCheck](#executewitherrorcheck)
+  * [EF Core TPH and GraphQL Interface](#ef-core-tph-and-graphql-interface)
+    * [EF Core Entities](#ef-core-entities)
+    * [GraphQL types](#graphql-types)
+    * [GraphQL query](#graphql-query)<!-- endtoc -->
 
 
 ## Container Registration
@@ -456,91 +459,6 @@ public class Entity1Graph :
 <!-- endsnippet -->
 
 
-### InterfaceGraphType
-
-Map a [table-per-hierarchy (TPH) EF Core pattern](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) to a [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) to describe the shared properties in the base type, and then each type in the hierarchy to its own GraphQL type.
-
-Given the following entities:
-
-<!-- snippet: InheritedEntity.cs -->
-<a id='snippet-InheritedEntity.cs'/></a>
-```cs
-using System;
-using System.Collections.Generic;
-
-public abstract class InheritedEntity
-{
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public string? Property { get; set; }
-    public IList<DerivedChildEntity> ChildrenFromBase { get; set; } = new List<DerivedChildEntity>();
-}
-```
-<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/InheritedEntity.cs#L1-L9' title='File snippet `InheritedEntity.cs` was extracted from'>snippet source</a> | <a href='#snippet-InheritedEntity.cs' title='Navigate to start of snippet `InheritedEntity.cs`'>anchor</a></sup>
-<!-- endsnippet -->
-
-<!-- snippet: DerivedEntity.cs -->
-<a id='snippet-DerivedEntity.cs'/></a>
-```cs
-using System;
-using System.Collections.Generic;
-
-public class DerivedEntity : InheritedEntity
-{
-}
-```
-<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedEntity.cs#L1-L6' title='File snippet `DerivedEntity.cs` was extracted from'>snippet source</a> | <a href='#snippet-DerivedEntity.cs' title='Navigate to start of snippet `DerivedEntity.cs`'>anchor</a></sup>
-<!-- endsnippet -->
-
-Create the following GraphQL types:
-
-<!-- snippet: InterfaceGraph.cs -->
-<a id='snippet-InterfaceGraph.cs'/></a>
-```cs
-using GraphQL.EntityFramework;
-using GraphQL.Types.Relay;
-
-public class InterfaceGraph :
-    EfInterfaceGraphType<IntegrationDbContext, InheritedEntity>
-{
-    public InterfaceGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
-        base(graphQlService)
-    {
-        Field(e => e.Id);
-        Field(e => e.Property, nullable: true);
-        AddNavigationConnectionField<DerivedChildEntity>(
-            name: "childrenFromInterface",
-            includeNames: new[] { "ChildrenFromBase" });
-    }
-}
-```
-<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/InterfaceGraph.cs#L1-L16' title='File snippet `InterfaceGraph.cs` was extracted from'>snippet source</a> | <a href='#snippet-InterfaceGraph.cs' title='Navigate to start of snippet `InterfaceGraph.cs`'>anchor</a></sup>
-<!-- endsnippet -->
-
-<!-- snippet: DerivedGraph.cs -->
-<a id='snippet-DerivedGraph.cs'/></a>
-```cs
-using GraphQL.EntityFramework;
-using GraphQL.Types.Relay;
-
-public class DerivedGraph :
-    EfObjectGraphType<IntegrationDbContext, DerivedEntity>
-{
-    public DerivedGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
-        base(graphQlService)
-    {
-        AddNavigationConnectionField<DerivedChildEntity>(
-            name: "childrenFromInterface",
-            e => e.Source.ChildrenFromBase);
-        AutoMap();
-        Interface<InterfaceGraph>();
-        IsTypeOf = obj => obj is DerivedEntity;
-    }
-}
-```
-<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedGraph.cs#L1-L17' title='File snippet `DerivedGraph.cs` was extracted from'>snippet source</a> | <a href='#snippet-DerivedGraph.cs' title='Navigate to start of snippet `DerivedGraph.cs`'>anchor</a></sup>
-<!-- endsnippet -->
-
-
 ## Testing the GraphQlController
 
 The `GraphQlController` can be tested using the [ASP.NET Integration tests](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests) via the [Microsoft.AspNetCore.Mvc.Testing NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing).
@@ -836,3 +754,98 @@ public static async Task<ExecutionResult> ExecuteWithErrorCheck(
 ```
 <sup><a href='/src/GraphQL.EntityFramework/GraphQlExtensions.cs#L9-L33' title='File snippet `executewitherrorcheck` was extracted from'>snippet source</a> | <a href='#snippet-executewitherrorcheck' title='Navigate to start of snippet `executewitherrorcheck`'>anchor</a></sup>
 <!-- endsnippet -->
+
+
+## EF Core TPH and GraphQL Interface
+
+Map a [table-per-hierarchy (TPH) EF Core pattern](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) to a [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) to describe the shared properties in the base type, and then each type in the hierarchy to its own GraphQL type. From now on, a GraphQL query returning the interface type could be defined, allowing clients to request either common properties or specific one using [inline fragments](https://graphql.org/learn/queries/#inline-fragments).
+
+### EF Core Entities
+
+<!-- snippet: InheritedEntity.cs -->
+<a id='snippet-InheritedEntity.cs'/></a>
+```cs
+using System;
+using System.Collections.Generic;
+
+public abstract class InheritedEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string? Property { get; set; }
+    public IList<DerivedChildEntity> ChildrenFromBase { get; set; } = new List<DerivedChildEntity>();
+}
+```
+<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/InheritedEntity.cs#L1-L9' title='File snippet `InheritedEntity.cs` was extracted from'>snippet source</a> | <a href='#snippet-InheritedEntity.cs' title='Navigate to start of snippet `InheritedEntity.cs`'>anchor</a></sup>
+<!-- endsnippet -->
+
+<!-- snippet: DerivedEntity.cs -->
+<a id='snippet-DerivedEntity.cs'/></a>
+```cs
+using System;
+using System.Collections.Generic;
+
+public class DerivedEntity : InheritedEntity
+{
+}
+```
+<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedEntity.cs#L1-L6' title='File snippet `DerivedEntity.cs` was extracted from'>snippet source</a> | <a href='#snippet-DerivedEntity.cs' title='Navigate to start of snippet `DerivedEntity.cs`'>anchor</a></sup>
+<!-- endsnippet -->
+
+### GraphQL types
+
+<!-- snippet: InterfaceGraph.cs -->
+<a id='snippet-InterfaceGraph.cs'/></a>
+```cs
+using GraphQL.EntityFramework;
+using GraphQL.Types.Relay;
+
+public class InterfaceGraph :
+    EfInterfaceGraphType<IntegrationDbContext, InheritedEntity>
+{
+    public InterfaceGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        Field(e => e.Id);
+        Field(e => e.Property, nullable: true);
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromInterface",
+            includeNames: new[] { "ChildrenFromBase" });
+    }
+}
+```
+<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/InterfaceGraph.cs#L1-L16' title='File snippet `InterfaceGraph.cs` was extracted from'>snippet source</a> | <a href='#snippet-InterfaceGraph.cs' title='Navigate to start of snippet `InterfaceGraph.cs`'>anchor</a></sup>
+<!-- endsnippet -->
+
+<!-- snippet: DerivedGraph.cs -->
+<a id='snippet-DerivedGraph.cs'/></a>
+```cs
+using GraphQL.EntityFramework;
+using GraphQL.Types.Relay;
+
+public class DerivedGraph :
+    EfObjectGraphType<IntegrationDbContext, DerivedEntity>
+{
+    public DerivedGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromInterface",
+            e => e.Source.ChildrenFromBase);
+        AutoMap();
+        Interface<InterfaceGraph>();
+        IsTypeOf = obj => obj is DerivedEntity;
+    }
+}
+```
+<sup><a href='/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedGraph.cs#L1-L17' title='File snippet `DerivedGraph.cs` was extracted from'>snippet source</a> | <a href='#snippet-DerivedGraph.cs' title='Navigate to start of snippet `DerivedGraph.cs`'>anchor</a></sup>
+<!-- endsnippet -->
+
+### GraphQL query
+
+```csharp
+efGraphQlService.AddQueryConnectionField(
+    this,
+    itemGraphType: typeof(InterfaceGraph),
+    name: "interfaceGraphConnection",
+    resolve: context => context.DbContext.InheritedEntities);
+```

--- a/doco/mdsource/configuration.source.md
+++ b/doco/mdsource/configuration.source.md
@@ -167,23 +167,6 @@ Use a DbContext in a Graph:
 snippet: Entity1Graph.cs
 
 
-### InterfaceGraphType
-
-Map a [table-per-hierarchy (TPH) EF Core pattern](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) to a [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) to describe the shared properties in the base type, and then each type in the hierarchy to its own GraphQL type.
-
-Given the following entities:
-
-snippet: InheritedEntity.cs
-
-snippet: DerivedEntity.cs
-
-Create the following GraphQL types:
-
-snippet: InterfaceGraph.cs
-
-snippet: DerivedGraph.cs
-
-
 ## Testing the GraphQlController
 
 The `GraphQlController` can be tested using the [ASP.NET Integration tests](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests) via the [Microsoft.AspNetCore.Mvc.Testing NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing).
@@ -201,3 +184,30 @@ The `GraphQlExtensions` class exposes some helper methods:
 Wraps the `DocumentExecuter.ExecuteAsync` to throw if there are any errors.
 
 snippet: ExecuteWithErrorCheck
+
+
+## EF Core TPH and GraphQL Interface
+
+Map a [table-per-hierarchy (TPH) EF Core pattern](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) to a [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) to describe the shared properties in the base type, and then each type in the hierarchy to its own GraphQL type. From now on, a GraphQL query returning the interface type could be defined, allowing clients to request either common properties or specific one using [inline fragments](https://graphql.org/learn/queries/#inline-fragments).
+
+### EF Core Entities
+
+snippet: InheritedEntity.cs
+
+snippet: DerivedEntity.cs
+
+### GraphQL types
+
+snippet: InterfaceGraph.cs
+
+snippet: DerivedGraph.cs
+
+### GraphQL query
+
+```csharp
+efGraphQlService.AddQueryConnectionField(
+    this,
+    itemGraphType: typeof(InterfaceGraph),
+    name: "interfaceGraphConnection",
+    resolve: context => context.DbContext.InheritedEntities);
+```

--- a/doco/mdsource/configuration.source.md
+++ b/doco/mdsource/configuration.source.md
@@ -167,6 +167,23 @@ Use a DbContext in a Graph:
 snippet: Entity1Graph.cs
 
 
+### InterfaceGraphType
+
+Map a [table-per-hierarchy (TPH) EF Core pattern](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) to a [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) to describe the shared properties in the base type, and then each type in the hierarchy to its own GraphQL type.
+
+Given the following entities:
+
+snippet: InheritedEntity.cs
+
+snippet: DerivedEntity.cs
+
+Create the following GraphQL types:
+
+snippet: InterfaceGraph.cs
+
+snippet: DerivedGraph.cs
+
+
 ## Testing the GraphQlController
 
 The `GraphQlController` can be tested using the [ASP.NET Integration tests](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests) via the [Microsoft.AspNetCore.Mvc.Testing NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing).

--- a/src/GraphQL.EntityFramework/GraphApi/EfInterfaceGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfInterfaceGraphType.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Types;
+using Microsoft.EntityFrameworkCore;
+
+namespace GraphQL.EntityFramework
+{
+    public class EfInterfaceGraphType<TDbContext, TSource> :
+        InterfaceGraphType<TSource>
+        where TDbContext : DbContext
+    {
+        public IEfGraphQLService<TDbContext> GraphQlService { get; }
+
+        public EfInterfaceGraphType(IEfGraphQLService<TDbContext> graphQlService)
+        {
+            Guard.AgainstNull(nameof(graphQlService), graphQlService);
+            GraphQlService = graphQlService;
+        }
+
+        public void AddNavigationConnectionField<TReturn>(
+            string name,
+            Type? graphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            IEnumerable<string>? includeNames = null,
+            int pageSize = 10)
+            where TReturn : class
+        {
+            GraphQlService.AddNavigationConnectionField<TSource, TReturn>(this, name, graphType, arguments, includeNames, pageSize);
+        }
+
+        public FieldType AddNavigationField<TReturn>(
+            string name,
+            Type? graphType = null,
+            IEnumerable<string>? includeNames = null)
+            where TReturn : class
+        {
+            return GraphQlService.AddNavigationField<TSource, TReturn>(this, name, graphType, includeNames);
+        }
+
+        public FieldType AddNavigationListField<TReturn>(
+            string name,
+            Type? graphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            IEnumerable<string>? includeNames = null)
+            where TReturn : class
+        {
+            return GraphQlService.AddNavigationListField<TSource, TReturn>(this, name, graphType, arguments, includeNames);
+        }
+
+        public void AddQueryConnectionField<TReturn>(
+            string name,
+            Type? graphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            int pageSize = 10)
+            where TReturn : class
+        {
+            GraphQlService.AddQueryConnectionField<TSource, TReturn>(this, name, graphType, arguments, pageSize);
+        }
+
+        public FieldType AddQueryField<TReturn>(
+            string name,
+            Type? graphType = null,
+            IEnumerable<QueryArgument>? arguments = null)
+            where TReturn : class
+        {
+            return GraphQlService.AddQueryField<TSource, TReturn>(this, name, graphType, arguments);
+        }
+
+        public TDbContext ResolveDbContext(ResolveFieldContext<TSource> context)
+        {
+            Guard.AgainstNull(nameof(context), context);
+            return GraphQlService.ResolveDbContext(context);
+        }
+
+        public TDbContext ResolveDbContext(ResolveFieldContext context)
+        {
+            Guard.AgainstNull(nameof(context), context);
+            return GraphQlService.ResolveDbContext(context);
+        }
+    }
+}

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Navigation.cs
@@ -9,7 +9,14 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, TReturn?> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, TReturn?> resolve,
+            Type? graphType = null,
+            IEnumerable<string>? includeNames = null)
+            where TReturn : class;
+
+        FieldType AddNavigationField<TSource, TReturn>(
+            InterfaceGraphType<TSource> graph,
+            string name,
             Type? graphType = null,
             IEnumerable<string>? includeNames = null)
             where TReturn : class;
@@ -17,7 +24,15 @@ namespace GraphQL.EntityFramework
         FieldType AddNavigationListField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IEnumerable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IEnumerable<TReturn>> resolve,
+            Type? itemGraphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            IEnumerable<string>? includeNames = null)
+            where TReturn : class;
+
+        FieldType AddNavigationListField<TSource, TReturn>(
+            InterfaceGraphType<TSource> graph,
+            string name,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null,
             IEnumerable<string>? includeNames = null)

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_NavigationConnection.cs
@@ -9,7 +9,16 @@ namespace GraphQL.EntityFramework
         void AddNavigationConnectionField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IEnumerable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IEnumerable<TReturn>> resolve,
+            Type? itemGraphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            IEnumerable<string>? includeNames = null,
+            int pageSize = 10)
+            where TReturn : class;
+
+        void AddNavigationConnectionField<TSource, TReturn>(
+            InterfaceGraphType<TSource> graph,
+            string name,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null,
             IEnumerable<string>? includeNames = null,

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_Queryable.cs
@@ -11,7 +11,7 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,object>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, object>, IQueryable<TReturn>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,object>, Task<IQueryable<TReturn>>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, object>, Task<IQueryable<TReturn>>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;
@@ -27,7 +27,7 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;
@@ -35,7 +35,7 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, Task<IQueryable<TReturn>>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, Task<IQueryable<TReturn>>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;
@@ -43,7 +43,7 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;
@@ -51,7 +51,14 @@ namespace GraphQL.EntityFramework
         FieldType AddQueryField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, Task<IQueryable<TReturn>>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, Task<IQueryable<TReturn>>> resolve,
+            Type? itemGraphType = null,
+            IEnumerable<QueryArgument>? arguments = null)
+            where TReturn : class;
+
+        FieldType AddQueryField<TSource, TReturn>(
+            InterfaceGraphType<TSource> graph,
+            string name,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null)
             where TReturn : class;

--- a/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IEfGraphQLService_QueryableConnection.cs
@@ -10,7 +10,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,object>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, object>, IQueryable<TReturn>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null,
             int pageSize = 10)
@@ -19,7 +19,7 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TSource, TReturn>(
             ObjectGraphType graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null,
             int pageSize = 10)
@@ -28,7 +28,15 @@ namespace GraphQL.EntityFramework
         void AddQueryConnectionField<TSource, TReturn>(
             ObjectGraphType<TSource> graph,
             string name,
-            Func<ResolveEfFieldContext<TDbContext,TSource>, IQueryable<TReturn>> resolve,
+            Func<ResolveEfFieldContext<TDbContext, TSource>, IQueryable<TReturn>> resolve,
+            Type? itemGraphType = null,
+            IEnumerable<QueryArgument>? arguments = null,
+            int pageSize = 10)
+            where TReturn : class;
+
+        void AddQueryConnectionField<TSource, TReturn>(
+            InterfaceGraphType<TSource> graph,
+            string name,
             Type? itemGraphType = null,
             IEnumerable<QueryArgument>? arguments = null,
             int pageSize = 10)

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -26,13 +26,13 @@ class IncludeAppender
 
         var type = typeof(TItem);
         var navigationProperty = navigations[type];
-        return AddIncludes(query, context.FieldDefinition, context.SubFields.Values, navigationProperty);
+        return AddIncludes(query, context, navigationProperty);
     }
 
-    IQueryable<T> AddIncludes<T>(IQueryable<T> query, FieldType fieldType, ICollection<Field> subFields, IReadOnlyList<Navigation> navigationProperties)
+    IQueryable<T> AddIncludes<T, TSource>(IQueryable<T> query, ResolveFieldContext<TSource> context, IReadOnlyList<Navigation> navigationProperties)
         where T : class
     {
-        var paths = GetPaths(fieldType, subFields, navigationProperties);
+        var paths = GetPaths(context, navigationProperties);
         foreach (var path in paths)
         {
             query = query.Include(path);
@@ -41,28 +41,48 @@ class IncludeAppender
         return query;
     }
 
-    List<string> GetPaths(FieldType fieldType, ICollection<Field> fields, IReadOnlyList<Navigation> navigationProperty)
+    List<string> GetPaths<TSource>(ResolveFieldContext<TSource> context, IReadOnlyList<Navigation> navigationProperty)
     {
         var list = new List<string>();
 
-        var graph = fieldType.GetComplexGraph();
-        ProcessSubFields(list, null, fields, graph, navigationProperty);
+        AddField(list, context.FieldAst, context.FieldAst.SelectionSet, null, context.FieldDefinition, navigationProperty, context);
+
         return list;
     }
 
-    void AddField(List<string> list, Field field, string? parentPath, FieldType fieldType, IReadOnlyList<Navigation> parentNavigationProperties)
+    void AddField<TSource>(List<string> list, Field field, SelectionSet selectionSet, string? parentPath, FieldType fieldType, IReadOnlyList<Navigation> parentNavigationProperties, ResolveFieldContext<TSource> context, IComplexGraphType? graph = null)
     {
-        if (!fieldType.TryGetComplexGraph(out var graph))
+        if (graph == null && !fieldType.TryGetComplexGraph(out graph))
         {
             return;
         }
 
-        var subFields = field.SelectionSet.Selections.OfType<Field>().ToList();
-        if (IsConnectionNode(field))
+        var subFields = selectionSet.Selections.OfType<Field>().ToList();
+
+        foreach (var inlineFragment in selectionSet.Selections.OfType<InlineFragment>())
+        {
+            if (inlineFragment.Type.GraphTypeFromType(context.Schema) is IComplexGraphType graphFragment)
+            {
+                AddField(list, field, inlineFragment.SelectionSet, parentPath, fieldType, parentNavigationProperties, context, graphFragment);
+            }
+        }
+
+        foreach (var fragmentSpread in selectionSet.Selections.OfType<FragmentSpread>())
+        {
+            var fragmentDefinition = context.Fragments.FindDefinition(fragmentSpread.Name);
+            if (fragmentDefinition == null)
+            {
+                continue;
+            }
+
+            AddField(list, field, fragmentDefinition.SelectionSet, parentPath, fieldType, parentNavigationProperties, context, graph);
+        }
+
+        if (IsConnectionNode(field) || field == context.FieldAst)
         {
             if (subFields.Count > 0)
             {
-                ProcessSubFields(list, parentPath, subFields, graph!, parentNavigationProperties);
+                ProcessSubFields(list, parentPath, subFields, graph!, parentNavigationProperties, context);
             }
 
             return;
@@ -85,7 +105,7 @@ class IncludeAppender
             list.Add(path);
         }
 
-        ProcessSubFields(list, paths.First(), subFields, graph!, navigations[entityType!]);
+        ProcessSubFields(list, paths.First(), subFields, graph!, navigations[entityType!], context);
     }
 
     static IEnumerable<string> GetPaths(string? parentPath, string[] includeNames)
@@ -98,15 +118,14 @@ class IncludeAppender
         return includeNames.Select(includeName => $"{parentPath}.{includeName}");
     }
 
-
-    void ProcessSubFields(List<string> list, string? parentPath, ICollection<Field> subFields, IComplexGraphType graph, IReadOnlyList<Navigation> navigationProperties)
+    void ProcessSubFields<TSource>(List<string> list, string? parentPath, ICollection<Field> subFields, IComplexGraphType graph, IReadOnlyList<Navigation> navigationProperties, ResolveFieldContext<TSource> context)
     {
         foreach (var subField in subFields)
         {
             var single = graph.Fields.SingleOrDefault(x => x.Name == subField.Name);
             if (single != null)
             {
-                AddField(list, subField, parentPath, single, navigationProperties);
+                AddField(list, subField, subField.SelectionSet, parentPath, single, navigationProperties, context);
             }
         }
     }
@@ -143,14 +162,14 @@ class IncludeAppender
 
     static string[] FieldNameToArray(string fieldName)
     {
-        return new[] {char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1)};
+        return new[] { char.ToUpperInvariant(fieldName[0]) + fieldName.Substring(1) };
     }
 
     static bool TryGetIncludeMetadata(FieldType fieldType, [NotNullWhen(true)] out string[]? value)
     {
         if (fieldType.Metadata.TryGetValue("_EF_IncludeName", out var fieldNameObject))
         {
-            value = (string[]) fieldNameObject;
+            value = (string[])fieldNameObject;
             return true;
         }
 

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedChildEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedChildEntity.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+public class DerivedChildEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string? Property { get; set; }
+    public Guid? ParentId { get; set; }
+    public InheritedEntity? Parent { get; set; }
+    public Guid? TypedParentId { get; set; }
+    public DerivedWithNavigationEntity? TypedParent { get; set; }
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedChildGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedChildGraph.cs
@@ -1,0 +1,12 @@
+﻿using GraphQL.EntityFramework;
+using System.Collections.Generic;
+
+public class DerivedChildGraph :
+    EfObjectGraphType<IntegrationDbContext, DerivedChildEntity>
+{
+    public DerivedChildGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AutoMap(new List<string> { "Parent", "TypedParent" });
+    }
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedEntity.cs
@@ -1,0 +1,6 @@
+﻿using System;
+using System.Collections.Generic;
+
+public class DerivedEntity : InheritedEntity
+{
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedGraph.cs
@@ -1,0 +1,17 @@
+﻿using GraphQL.EntityFramework;
+using GraphQL.Types.Relay;
+
+public class DerivedGraph :
+    EfObjectGraphType<IntegrationDbContext, DerivedEntity>
+{
+    public DerivedGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromInterface",
+            e => e.Source.ChildrenFromBase);
+        AutoMap();
+        Interface<InterfaceGraph>();
+        IsTypeOf = obj => obj is DerivedEntity;
+    }
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedWithNavigationEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedWithNavigationEntity.cs
@@ -1,0 +1,7 @@
+﻿using System;
+using System.Collections.Generic;
+
+public class DerivedWithNavigationEntity : InheritedEntity
+{
+    public IList<DerivedChildEntity> Children { get; set; } = new List<DerivedChildEntity>();
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedWithNavigationGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/DerivedWithNavigationGraph.cs
@@ -1,0 +1,21 @@
+﻿using GraphQL.EntityFramework;
+using GraphQL.Types.Relay;
+
+public class DerivedWithNavigationGraph :
+    EfObjectGraphType<IntegrationDbContext, DerivedWithNavigationEntity>
+{
+    public DerivedWithNavigationGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromInterface",
+            e => e.Source.ChildrenFromBase);
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromDerived",
+            e => e.Source.Children,
+            includeNames: new[] { "Children" });
+        AutoMap();
+        Interface<InterfaceGraph>();
+        IsTypeOf = obj => obj is DerivedWithNavigationEntity;
+    }
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/InheritedEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/InheritedEntity.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+
+public abstract class InheritedEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string? Property { get; set; }
+    public IList<DerivedChildEntity> ChildrenFromBase { get; set; } = new List<DerivedChildEntity>();
+}

--- a/src/Tests/IntegrationTests/Graphs/Inheritance/InterfaceGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/Inheritance/InterfaceGraph.cs
@@ -1,0 +1,16 @@
+﻿using GraphQL.EntityFramework;
+using GraphQL.Types.Relay;
+
+public class InterfaceGraph :
+    EfInterfaceGraphType<IntegrationDbContext, InheritedEntity>
+{
+    public InterfaceGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        Field(e => e.Id);
+        Field(e => e.Property, nullable: true);
+        AddNavigationConnectionField<DerivedChildEntity>(
+            name: "childrenFromInterface",
+            includeNames: new[] { "ChildrenFromBase" });
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.InheritedEntityInterface.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.InheritedEntityInterface.verified.txt
@@ -1,0 +1,36 @@
+{
+  interfaceGraphConnection: {
+    items: [
+      {
+        property: 'Value1',
+        childrenFromInterface: {
+          items: [
+            {
+              property: 'Value2'
+            },
+            {
+              property: 'Value3'
+            }
+          ]
+        }
+      },
+      {
+        property: 'Value4',
+        childrenFromInterface: {
+          items: [
+            {
+              property: 'Value5'
+            }
+          ]
+        },
+        childrenFromDerived: {
+          items: [
+            {
+              property: 'Value6'
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_WithFragment.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_WithFragment.verified.txt
@@ -1,0 +1,13 @@
+{
+  parentEntity: {
+    property: 'Value1',
+    children: [
+      {
+        property: 'Value2'
+      },
+      {
+        property: 'Value3'
+      }
+    ]
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -492,7 +492,7 @@ query ($value: String!)
 mutation {
   parentEntityMutation(id: ""00000000-0000-0000-0000-000000000001"") {
     property
-    children
+    children(orderBy: {path: ""property""})
     {
       property
     }
@@ -539,10 +539,60 @@ mutation {
 {
   parentEntity(id: ""00000000-0000-0000-0000-000000000001"") {
     property
-    children
+    children(orderBy: {path: ""property""})
     {
       property
     }
+  }
+}";
+
+        var entity1 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Property = "Value1"
+        };
+        var entity2 = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = entity1
+        };
+        var entity3 = new ChildEntity
+        {
+            Property = "Value3",
+            Parent = entity1
+        };
+        entity1.Children.Add(entity2);
+        entity1.Children.Add(entity3);
+        var entity4 = new ParentEntity
+        {
+            Property = "Value4"
+        };
+        var entity5 = new ChildEntity
+        {
+            Property = "Value5",
+            Parent = entity4
+        };
+        entity4.Children.Add(entity5);
+
+        await using var database = await sqlInstance.Build();
+        var result = await RunQuery(database, query, null, null, entity1, entity2, entity3, entity4, entity5);
+        await Verifier.Verify(result);
+    }
+
+    [Fact]
+    public async Task SingleParent_Child_WithFragment()
+    {
+        var query = @"
+{
+  parentEntity(id: ""00000000-0000-0000-0000-000000000001"") {
+    ...parentEntityFields
+  }
+}
+fragment parentEntityFields on ParentGraph {
+  property
+  children(orderBy: {path: ""property""})
+  {
+    property
   }
 }";
 
@@ -1313,7 +1363,7 @@ query ($id: String!)
             services.AddSingleton(type);
         }
 
-        return await QueryExecutor.ExecuteQuery(query, services, dbContext, inputs, filters);
+        return await QueryExecutor.ExecuteQuery(query, services, database.NewDbContext(), inputs, filters);
     }
 
     static IEnumerable<Type> GetGraphQlTypes()

--- a/src/Tests/IntegrationTests/MyDataContext.cs
+++ b/src/Tests/IntegrationTests/MyDataContext.cs
@@ -21,6 +21,7 @@ public class IntegrationDbContext :
     public DbSet<Child1Entity> Child1Entities { get; set; } = null!;
     public DbSet<Child2Entity> Child2Entities { get; set; } = null!;
     public DbSet<ParentEntityView> ParentEntityView { get; set; } = null!;
+    public DbSet<InheritedEntity> InheritedEntities { get; set; } = null!;
 
     public IntegrationDbContext(DbContextOptions options) :
         base(options)
@@ -53,5 +54,11 @@ public class IntegrationDbContext :
         modelBuilder.Entity<Child1Entity>();
         modelBuilder.Entity<NamedIdEntity>();
         modelBuilder.Entity<Child2Entity>();
+        modelBuilder.Entity<DerivedEntity>().HasBaseType<InheritedEntity>();
+        modelBuilder.Entity<DerivedWithNavigationEntity>()
+            .HasBaseType<InheritedEntity>()
+            .HasMany(e => e.Children)
+            .WithOne(e => e.TypedParent!)
+            .HasForeignKey(e => e.TypedParentId);
     }
 }

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -80,5 +80,11 @@ public class Query :
             name: "parentEntityNullable",
             resolve: context => context.DbContext.ParentEntities,
             nullable: true);
+
+        efGraphQlService.AddQueryConnectionField(
+            this,
+            itemGraphType: typeof(InterfaceGraph),
+            name: "interfaceGraphConnection",
+            resolve: context => context.DbContext.InheritedEntities);
     }
 }

--- a/src/Tests/IntegrationTests/Schema.cs
+++ b/src/Tests/IntegrationTests/Schema.cs
@@ -8,5 +8,7 @@ public class Schema :
     {
         Query = resolver.Resolve<Query>();
         Mutation = resolver.Resolve<Mutation>();
+        RegisterType<DerivedGraph>();
+        RegisterType<DerivedWithNavigationGraph>();
     }
 }


### PR DESCRIPTION
#### Guidance

The way this library does add conditional includes based on the content of the GraphQL query is a great feature. Unfortunately, it was not working when the field that requires an explicit include was nested in a [GraphQL fragment](https://graphql.org/learn/queries/#fragments) because of the way the queried fields were detected in the `IncludeAppender` class.

Furthermore, this library could offer a support of [GraphQL interfaces](https://graphql-dotnet.github.io/docs/getting-started/interfaces) mapped on an [EF Core table-per-hierarchy (TPH)](https://docs.microsoft.com/en-us/ef/core/modeling/inheritance) base class. This would allow to expose a common GraphQL query for many derived entities while preserving the ability to query specific fields thanks to the support of [inline fragments](https://graphql.org/learn/queries/#inline-fragments).

#### Description

My first personal need was to add support for interfaces, as my current project does implement a TPH pattern. But to support GraphQL interfaces, I should fix the ability to detect conditional includes inside fragments (inline or named), so as there were already 2 issues about this, I decided to do it all.

With this PR merged, GraphQL.EntityFramework would be able to:
- Detect any include to add to the Queryable, even if the corresponding field is nested in any kind of fragment hierarchy
- Declare a GraphQL interface mapped on a TPH base class to expose all entities in the same hierarchy through one unique query

I already tested my implementation in the context of my current project (by referencing my local changes instead of your NuGet package), and it works great!

#### The solution

##### Rework of the `IncludeAppender` class
- It does now recurse the `AddField` private method if any named or inline fragment are detected, giving the corresponding `SelectionSet` to the recursion
- In case of an inline fragment, we should get the `IComplexGraphType` corresponding on the targeted type (which will be the graph representation of one of the derived TPH entity), so I added an optional parameter `graph` and avoid the automatic detection from the field type if given
- Named fragments should be find in `ResolveFieldContext<TSource>` from its spread, so I added the context as a parameter of the method `AddField`
- To properly recurse from the root field node inside all kind of fragments, I'm now calling directly `AddField` from `GetPaths` (instead of `ProcessSubFields`), and [force to add sub fields when it is the root node like you did for connection types](https://github.com/SimonCropp/GraphQL.EntityFramework/compare/master...asiffermann:master#diff-a4731117f500aa011bd5b9c7868a29d2R81).
- I did hesitate to merge the private methods `AddIncludes` and `GetPaths` into the public `AddIncludes` one for clarity, but I preferred to minimize as much as possible the changes this PR brings.

##### `EfInterfaceGraphType`
- A [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces) should add fields only with proper type and name, but no resolve. But it should still eventually declare the corresponding `includeName` for any navigation property it owns. And it couldn't implement `ObjectGraphType` or it will not properly be detected as an interface in the GraphQL schema.
- So I created a sibling class to the existing `EfObjectGraphType` dedicated to interfaces: `EfInterfaceGraphType`
- All methods of `IEfGraphQLService` are taking a `ObjectGraphType` as first parameter, so to avoid breaking changes, I declared explicit methods to work on an `InterfaceGraphType`, without the `resolve` parameter. I could rather add fields directly from the methods in `EfInterfaceGraphType`, but I wouldn't be able to use some parts of the existing code (for example `MakeListGraphType` which is a private static method of `EfGraphQLService`, so I thought it was cleaner like this.
- To share the same code used by object types, I made the `resolve` parameter of each private method nullable, and move the Guard protection on it to the calling method.

##### Unit tests
- **SingleParent_Child_WithFragment**: it is exactly the same data as the unit test `SingleParent_Child`, but the executed GraphQL query contains nested fragments (similar to #381)
- **InheritedEntityInterface**: a full integration test with TPH, GraphQL interface, nested named and inline fragments.
- To be sure these new tests failed without my fixes, I give a new DbContext (using `database.NewDbContext()`) as a parameter of the document executor. Without that, the DbContext would already have all navigation properties loaded (because the test just created it), so the tests on includes wouldn't be accurate. This change brings an ordering of child entities based on their Guid identifier, that's why I explicitely ordered children in the unit tests `SingleParent_Child_mutation` and `SingleParent_Child`
- I wasn't confident on the naming conventions in the test project, so I tried my best to stick to it, but it could be wrong

##### Documentation
- I added to the documentation an example of mapping TPH entities and Graph types.
- I did not add any reference about fragments handling, as I feel it is more a bugfix to respect the GraphQL specification than a new feature

#### Todos

 * [x] Related issues : #377 #11
 * [x] Tests
 * [x] Documentation

I hope my explanations are clear enough, and am looking forward to be able to use GraphQL interfaces with GraphQL.EntityFramework!