### PR TITLE
Fix NullableTypes.IsNullable interpretation of nullable string

### DIFF
--- a/src/GraphQL.EntityFramework/Mapping/NullableTypes.cs
+++ b/src/GraphQL.EntityFramework/Mapping/NullableTypes.cs
@@ -48,7 +48,8 @@ namespace GraphQL.EntityFramework
                     }
                 }
 
-                return false;
+                //Do not return false here due to this causes interpretation of nullable string in #nullable disable case as non nullable one.
+                //return false;
             }
 
             return propertyType.IsNullable();

--- a/src/Tests/NullableTypesTests.cs
+++ b/src/Tests/NullableTypesTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel.DataAnnotations;
 using GraphQL.EntityFramework;
 using Xunit;
 
@@ -30,4 +32,29 @@ public class NullableTypesTests
     }
 
     public record TargetRecord(string Property, string? NullProperty);
+
+    //Ensure NullableTypes.IsNullable does not interpret nullable string in #nullable disable as non nullable one
+#nullable disable
+
+    [Fact]
+    public void ClassNullableDisable()
+    {
+        var nullProperty = typeof(TargetClassNullableDisable).GetProperty("NullProperty")!;
+        Assert.True(nullProperty.IsNullable());
+    }
+
+    [Fact]
+    public void RecordNullableDisable()
+    {
+        var nullProperty = typeof(TargetRecordNullableDisable).GetProperty("NullProperty")!;
+        Assert.True(nullProperty.IsNullable());
+    }
+
+    public class TargetClassNullableDisable
+    {
+        [Required]
+        public string NullProperty { get; }
+    }
+
+    public record TargetRecordNullableDisable(string NullProperty);
 }


### PR DESCRIPTION
NullableTypes.IsNullable is fixed to support a nullable string type in case of entity class is defined under #nullable disable

P.S. I know I'm not a patron. This is my 5 cents for this project for .Net 5.0 compatibility. Under MIT.
