### PR TITLE
DbContextFromProvider is fixed for the case HttpContext is null.

### DIFF
--- a/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
@@ -55,7 +55,7 @@ namespace GraphQL.EntityFramework
         {
             var dataFromHttpContext = provider.GetService<HttpContextCapture>()?
                 .HttpContextAccessor?
-                .HttpContext
+                .HttpContext?
                 .RequestServices
                 .GetService<TDbContext>();
             if (dataFromHttpContext != null)


### PR DESCRIPTION
A little fix to avoid crash in non asp.net test environment.