### PR TITLE
Support of including of EF Core 5.0 many-to-many navigation properties

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
@@ -63,11 +63,13 @@ namespace GraphQL.EntityFramework
                     {
                         var fieldContext = BuildContext(context);
                         var names = GetKeyNames<TReturn>();
-                        var query = resolve(fieldContext).AsNoTracking();
+                        var query = resolve(fieldContext);
                         query = includeAppender.AddIncludes(query, context);
                         query = query.ApplyGraphQlArguments(context, names);
 
-                        var list = await query.ToListAsync(context.CancellationToken);
+                        var list = await query
+                            .AsNoTracking()
+                            .ToListAsync(context.CancellationToken);
                         return await fieldContext.Filters.ApplyFilter(list, context.UserContext);
                     });
             }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
@@ -63,7 +63,7 @@ namespace GraphQL.EntityFramework
                     {
                         var fieldContext = BuildContext(context);
                         var names = GetKeyNames<TReturn>();
-                        var query = resolve(fieldContext);
+                        var query = resolve(fieldContext).AsNoTracking();
                         query = includeAppender.AddIncludes(query, context);
                         query = query.ApplyGraphQlArguments(context, names);
 

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftEntity.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 public class ManyToManyLeftEntity
@@ -10,7 +9,7 @@ public class ManyToManyLeftEntity
     }
 
     [Key]
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Id { get; set; } = null!;
 
     public string? LeftName { get; set; }
 

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftEntity.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+public class ManyToManyLeftEntity
+{
+    public ManyToManyLeftEntity()
+    {
+        Rights = new HashSet<ManyToManyRightEntity>();
+    }
+
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string? LeftName { get; set; }
+
+    public IEnumerable<ManyToManyRightEntity> Rights { get; set; }
+}

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyLeftGraph.cs
@@ -1,0 +1,11 @@
+﻿using GraphQL.EntityFramework;
+
+public class ManyToManyLeftGraph :
+    EfObjectGraphType<IntegrationDbContext, ManyToManyLeftEntity>
+{
+    public ManyToManyLeftGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AutoMap();
+    }
+}

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyMiddleEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyMiddleEntity.cs
@@ -1,0 +1,5 @@
+﻿public class ManyToManyMiddleEntity
+{
+    public ManyToManyLeftEntity ManyToManyLeftEntity { get; set; } = null!;
+    public ManyToManyRightEntity ManyToManyRightEntity { get; set; } = null!;
+}

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightEntity.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+public class ManyToManyRightEntity
+{
+    public ManyToManyRightEntity()
+    {
+        Lefts = new HashSet<ManyToManyLeftEntity>();
+    }
+
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string? RightName { get; set; }
+
+    public ICollection<ManyToManyLeftEntity> Lefts { get; set; }
+}

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightEntity.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 public class ManyToManyRightEntity
@@ -10,7 +9,7 @@ public class ManyToManyRightEntity
     }
 
     [Key]
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Id { get; set; } = null!;
 
     public string? RightName { get; set; }
 

--- a/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightGraph.cs
+++ b/src/Tests/IntegrationTests/Graphs/ManyToMany/ManyToManyRightGraph.cs
@@ -1,0 +1,11 @@
+﻿using GraphQL.EntityFramework;
+
+public class ManyToManyRightGraph :
+    EfObjectGraphType<IntegrationDbContext, ManyToManyRightEntity>
+{
+    public ManyToManyRightGraph(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AutoMap();
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
@@ -1,8 +1,11 @@
 {
   manyToManyRightEntities: [
     {
-      rightName: Right2,
+      rightName: Right1,
       lefts: [
+        {
+          leftName: Left1
+        },
         {
           leftName: Left2
         }

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
@@ -1,0 +1,12 @@
+{
+  manyToManyRightEntities: [
+    {
+      rightName: Right2,
+      lefts: [
+        {
+          leftName: Left2
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyRightWhereAndInclude.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyRightWhereAndInclude.verified.txt
@@ -1,0 +1,12 @@
+{
+  manyToManyLeftEntities: [
+    {
+      leftName: Left2,
+      rights: [
+        {
+          rightName: Right2
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyRightWhereAndInclude.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyRightWhereAndInclude.verified.txt
@@ -1,8 +1,11 @@
 {
   manyToManyLeftEntities: [
     {
-      leftName: Left2,
+      leftName: Left1,
       rights: [
+        {
+          rightName: Right1
+        },
         {
           rightName: Right2
         }

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -39,6 +39,8 @@ public partial class IntegrationTests
         GraphTypeTypeRegistry.Register<DerivedEntity, DerivedGraph>();
         GraphTypeTypeRegistry.Register<DerivedWithNavigationEntity, DerivedWithNavigationGraph>();
         GraphTypeTypeRegistry.Register<DerivedChildEntity, DerivedChildGraph>();
+        GraphTypeTypeRegistry.Register<ManyToManyLeftEntity, ManyToManyLeftGraph>();
+        GraphTypeTypeRegistry.Register<ManyToManyRightEntity, ManyToManyRightGraph>();
 
         sqlInstance = new SqlInstance<IntegrationDbContext>(
             buildTemplate: async data =>
@@ -1383,6 +1385,94 @@ fragment childEntityFields on DerivedChildGraph {
 
         await using var database = await sqlInstance.Build();
         var result = await RunQuery(database, query, null, null, derivedEntity1, childEntity1, childEntity2, derivedEntity2, childEntity3, childEntity4);
+        await Verifier.Verify(result);
+    }
+
+    [Fact]
+    public async Task ManyToManyRightWhereAndInclude()
+    {
+        var query = @"
+{
+  manyToManyLeftEntities (where: {path: 'rights[rightName]', comparison: 'equal', value: ""Right2""})
+  {
+    leftName
+    rights
+    {
+      rightName
+    }
+  }
+}";
+
+        var middle11 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                LeftName = "Left1"
+            },
+            ManyToManyRightEntity = new ManyToManyRightEntity
+            {
+                RightName = "Right1"
+            }
+        };
+
+        var middle22 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                LeftName = "Left2"
+            },
+            ManyToManyRightEntity = new ManyToManyRightEntity
+            {
+                RightName = "Right2"
+            }
+        };
+
+        await using var database = await sqlInstance.Build();
+        var result = await RunQuery(database, query, null, null, middle11, middle22);
+        await Verifier.Verify(result);
+    }
+
+    [Fact]
+    public async Task ManyToManyLeftWhereAndInclude()
+    {
+        var query = @"
+{
+  manyToManyRightEntities (where: {path: 'lefts[leftName]', comparison: 'equal', value: ""Left2""})
+  {
+    rightName
+    lefts
+    {
+      leftName
+    }
+  }
+}";
+
+        var middle11 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                LeftName = "Left1"
+            },
+            ManyToManyRightEntity = new ManyToManyRightEntity
+            {
+                RightName = "Right1"
+            }
+        };
+
+        var middle22 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                LeftName = "Left2"
+            },
+            ManyToManyRightEntity = new ManyToManyRightEntity
+            {
+                RightName = "Right2"
+            }
+        };
+
+        await using var database = await sqlInstance.Build();
+        var result = await RunQuery(database, query, null, null, middle11, middle22);
         await Verifier.Verify(result);
     }
 

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -1407,28 +1407,38 @@ fragment childEntityFields on DerivedChildGraph {
         {
             ManyToManyLeftEntity = new ManyToManyLeftEntity
             {
+                Id = "Left1Id",
                 LeftName = "Left1"
             },
             ManyToManyRightEntity = new ManyToManyRightEntity
             {
+                Id = "Right1Id",
                 RightName = "Right1"
             }
         };
 
-        var middle22 = new ManyToManyMiddleEntity
+        var middle12 = new ManyToManyMiddleEntity
         {
-            ManyToManyLeftEntity = new ManyToManyLeftEntity
-            {
-                LeftName = "Left2"
-            },
+            ManyToManyLeftEntity = middle11.ManyToManyLeftEntity,
             ManyToManyRightEntity = new ManyToManyRightEntity
             {
+                Id = "Right2Id",
                 RightName = "Right2"
             }
         };
 
+        var middle21 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                Id = "Left2Id",
+                LeftName = "Left2"
+            },
+            ManyToManyRightEntity = middle11.ManyToManyRightEntity
+        };
+
         await using var database = await sqlInstance.Build();
-        var result = await RunQuery(database, query, null, null, middle11, middle22);
+        var result = await RunQuery(database, query, null, null, middle11, middle12, middle21);
         await Verifier.Verify(result);
     }
 
@@ -1451,28 +1461,38 @@ fragment childEntityFields on DerivedChildGraph {
         {
             ManyToManyLeftEntity = new ManyToManyLeftEntity
             {
+                Id = "Left1Id",
                 LeftName = "Left1"
             },
             ManyToManyRightEntity = new ManyToManyRightEntity
             {
+                Id = "Right1Id",
                 RightName = "Right1"
             }
         };
 
-        var middle22 = new ManyToManyMiddleEntity
+        var middle12 = new ManyToManyMiddleEntity
         {
-            ManyToManyLeftEntity = new ManyToManyLeftEntity
-            {
-                LeftName = "Left2"
-            },
+            ManyToManyLeftEntity = middle11.ManyToManyLeftEntity,
             ManyToManyRightEntity = new ManyToManyRightEntity
             {
+                Id = "Right2Id",
                 RightName = "Right2"
             }
         };
 
+        var middle21 = new ManyToManyMiddleEntity
+        {
+            ManyToManyLeftEntity = new ManyToManyLeftEntity
+            {
+                Id = "Left2Id",
+                LeftName = "Left2"
+            },
+            ManyToManyRightEntity = middle11.ManyToManyRightEntity
+        };
+
         await using var database = await sqlInstance.Build();
-        var result = await RunQuery(database, query, null, null, middle11, middle22);
+        var result = await RunQuery(database, query, null, null, middle11, middle12, middle21);
         await Verifier.Verify(result);
     }
 

--- a/src/Tests/IntegrationTests/MyDataContext.cs
+++ b/src/Tests/IntegrationTests/MyDataContext.cs
@@ -22,6 +22,9 @@ public class IntegrationDbContext :
     public DbSet<Child2Entity> Child2Entities { get; set; } = null!;
     public DbSet<ParentEntityView> ParentEntityView { get; set; } = null!;
     public DbSet<InheritedEntity> InheritedEntities { get; set; } = null!;
+    public DbSet<ManyToManyLeftEntity> ManyToManyLeftEntities { get; set; } = null!;
+    public DbSet<ManyToManyRightEntity> ManyToManyRightEntities { get; set; } = null!;
+    public DbSet<ManyToManyMiddleEntity> ManyToManyMiddleEntities { get; set; } = null!;
 
     public IntegrationDbContext(DbContextOptions options) :
         base(options)
@@ -60,5 +63,11 @@ public class IntegrationDbContext :
             .HasMany(e => e.Children)
             .WithOne(e => e.TypedParent!)
             .HasForeignKey(e => e.TypedParentId);
+        modelBuilder.Entity<ManyToManyRightEntity>()
+            .HasMany(r => r.Lefts)
+            .WithMany(l => l.Rights)
+            .UsingEntity<ManyToManyMiddleEntity>(
+                x => x.HasOne(xs => xs.ManyToManyLeftEntity).WithMany(),
+                x => x.HasOne(xs => xs.ManyToManyRightEntity).WithMany());
     }
 }

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -86,5 +86,13 @@ public class Query :
             itemGraphType: typeof(InterfaceGraph),
             name: "interfaceGraphConnection",
             resolve: context => context.DbContext.InheritedEntities);
+
+        AddQueryField(
+            name: "manyToManyLeftEntities",
+            resolve: context => context.DbContext.ManyToManyLeftEntities);
+
+        AddQueryField(
+            name: "manyToManyRightEntities",
+            resolve: context => context.DbContext.ManyToManyRightEntities);
     }
 }


### PR DESCRIPTION
EF Core 5.0 brings a many-to-many navigation support uning a new type of navigations implementing a ISkipNavigation interface. This PR extends a navigation property extraction with such navigation properties as well. Also there is a known issue with inclusion of such properties in a root queryable loading. AsNoTracking enables a loading.