### PR TITLE
Repro of Owned Entity issue in KeyNameExtractor.cs

### DIFF
--- a/src/SampleWeb/DataContext/OrderDetail.cs
+++ b/src/SampleWeb/DataContext/OrderDetail.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+public class OrderDetail
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public StreetAddress ShippingAddress { get; set; } = null!;
+    public StreetAddress BillingAddress { get; set; } = null!;
+}

--- a/src/SampleWeb/DataContext/SampleDbContext.cs
+++ b/src/SampleWeb/DataContext/SampleDbContext.cs
@@ -6,6 +6,8 @@ public class SampleDbContext :
 {
     public DbSet<Employee> Employees { get; set; } = null!;
     public DbSet<Company> Companies { get; set; } = null!;
+    public DbSet<OrderDetail> OrderDetails { get; set; } = null!;
+
     public static IModel StaticModel { get; } = BuildStaticModel();
 
     public SampleDbContext(DbContextOptions options) :
@@ -28,5 +30,9 @@ public class SampleDbContext :
             .WithOne(e => e.Company)
             .IsRequired();
         modelBuilder.Entity<Employee>();
+
+        modelBuilder.Entity<OrderDetail>().OwnsOne(p => p.BillingAddress);
+        modelBuilder.Entity<OrderDetail>().OwnsOne(p => p.ShippingAddress);
+
     }
 }

--- a/src/SampleWeb/DataContext/StreetAddress.cs
+++ b/src/SampleWeb/DataContext/StreetAddress.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+[Owned]
+public class StreetAddress
+{
+    public string AddressLine1 { get; set; } = null!;
+    public string? AddressLine2 { get; set; }
+    public string State { get; set; } = null!;
+    public string AreaCode { get; set; } = null!;
+    public string Country { get; set; } = null!;
+}

--- a/src/SampleWeb/DbContextBuilder.cs
+++ b/src/SampleWeb/DbContextBuilder.cs
@@ -62,6 +62,28 @@ public class DbContextBuilder :
             CompanyId = company2.Id
         };
         context.AddRange(company1, employee1, employee2, company2, company3, company4, employee4, employee5);
+
+
+        var orderDetail1 = new OrderDetail
+        {
+            Id = 1,
+            BillingAddress = new StreetAddress
+            {
+                AddressLine1 = "1 Street",
+                AreaCode = "1234",
+                State = "New South Wales",
+                Country = "Australia"
+            },
+            ShippingAddress = new StreetAddress
+            {
+                AddressLine1 = "1 Street",
+                AreaCode = "1234",
+                State = "New South Wales",
+                Country = "Australia"
+            }
+        };
+        context.OrderDetails.Add(orderDetail1);
+
         await context.SaveChangesAsync();
     }
 

--- a/src/SampleWeb/Graphs/CompanyGraph.cs
+++ b/src/SampleWeb/Graphs/CompanyGraph.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQL.EntityFramework;
+using GraphQL.Types;
 
 public class CompanyGraph :
     EfObjectGraphType<SampleDbContext, Company>
@@ -13,6 +14,15 @@ public class CompanyGraph :
             name: "employeesConnection",
             resolve: context => context.Source.Employees,
             includeNames: new[] {"Employees"});
+        AutoMap();
+    }
+}
+
+public class OrderDetailGraph :
+    EfObjectGraphType<SampleDbContext, OrderDetail>
+{
+    public OrderDetailGraph(IEfGraphQLService<SampleDbContext> graphQlService) : base(graphQlService)
+    {
         AutoMap();
     }
 }


### PR DESCRIPTION
Added an Owned Entity to the sample DB Context to illustrate the problem with the KeyNameExtractor.cs

This causes a runtime exception:
```
System.ArgumentException
  HResult=0x80070057
  Message=An item with the same key has already been added. Key: StreetAddress
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException[T](T key)
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at KeyNameExtractor.GetKeyNames(IModel model) in C:\code\GraphQL.EntityFramework\src\GraphQL.EntityFramework\KeyNameExtractor.cs:line 22
   at GraphQL.EntityFramework.EfGraphQLService`1..ctor(IModel model, ResolveDbContext`1 resolveDbContext, ResolveFilters resolveFilters, Boolean disableTracking) in C:\code\GraphQL.EntityFramework\src\GraphQL.EntityFramework\GraphApi\EfGraphQLService.cs:line 32
   at GraphQL.EntityFramework.EfGraphQLConventions.Build[TDbContext](ResolveDbContext`1 dbContextResolver, IModel model, ResolveFilters filters, IServiceProvider provider, Boolean disableTracking) in C:\code\GraphQL.EntityFramework\src\GraphQL.EntityFramework\EfGraphQLConventions.cs:line 51
   at GraphQL.EntityFramework.EfGraphQLConventions.<>c__DisplayClass0_0`1.<RegisterInContainer>b__0(IServiceProvider provider) in C:\code\GraphQL.EntityFramework\src\GraphQL.EntityFramework\EfGraphQLConventions.cs:line 36
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite singletonCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite singletonCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite singletonCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.DynamicServiceProviderEngine.<>c__DisplayClass1_0.<RealizeService>b__0(ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngine.GetService(Type serviceType, ServiceProviderEngineScope serviceProviderEngineScope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.GetService(IServiceProvider sp, Type type, Type requiredBy, Boolean isDefaultParameterRequired)
   at Microsoft.AspNetCore.Mvc.Controllers.ControllerActivatorProvider.<>c__DisplayClass4_0.<CreateActivator>b__0(ControllerContext controllerContext)
   at Microsoft.AspNetCore.Mvc.Controllers.ControllerFactoryProvider.<>c__DisplayClass5_0.<CreateControllerFactory>g__CreateController|0(ControllerContext controllerContext)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
```

I assume the fix would be to test for the existance of the type in the keynames dictionary before adding it