### PR TITLE
Multi-target to .NET Standard 2.1

### DIFF
--- a/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
+++ b/src/GraphQL.EntityFramework/GraphQL.EntityFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <Description>Add EntityFramework Core IQueryable support to GraphQL</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/GraphQL.EntityFramework/IsExternalInit.cs
+++ b/src/GraphQL.EntityFramework/IsExternalInit.cs
@@ -1,0 +1,8 @@
+﻿#if(NETSTANDARD2_1)
+namespace System.Runtime.CompilerServices
+{
+    public class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/GraphQL.EntityFramework/Where/Graphs/ArgumentGraphs.cs
+++ b/src/GraphQL.EntityFramework/Where/Graphs/ArgumentGraphs.cs
@@ -9,7 +9,9 @@ static class ArgumentGraphs
 {
     static Dictionary<Type, GraphType> entries = new();
 
+#if !NETSTANDARD2_1
     [ModuleInitializer]
+#endif
     public static void Initialize()
     {
         Add<StringComparisonGraph>();


### PR DESCRIPTION
I know how you feel about multi-targeting, but if you're keen to support .NET Standard 2.1, it's only a couple of lines of code to change. This is for an NFP and we don't know if we will be able to run with .NET 5 yet.