### PR TITLE
I would like it to be possible to inject the context resolver and fil…

### DIFF
--- a/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
@@ -81,7 +81,7 @@ namespace GraphQL.EntityFramework
             throw new($"Could not extract {typeof(TDbContext).Name} from the provider. Tried the HttpContext provider and the root provider.");
         }
 
-        static void RegisterScalarsAndArgs(IServiceCollection services)
+        public static void RegisterScalarsAndArgs(IServiceCollection services)
         {
             ArgumentGraphs.RegisterInContainer(services);
         }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.EntityFramework.GraphApi;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -26,6 +27,24 @@ namespace GraphQL.EntityFramework
             this.disableTracking = disableTracking;
 
             this.resolveDbContext = resolveDbContext;
+
+            keyNames = model.GetKeyNames();
+
+            Navigations = NavigationReader.GetNavigationProperties(model);
+            includeAppender = new(Navigations);
+        }
+        
+        public EfGraphQLService
+        (
+            IModel model,
+            IDbContextResolver<TDbContext> contextResolver,
+            IFilterResolver filterResolver,
+            bool disableTracking = false
+        )
+        {
+            this.resolveFilters = filterResolver.ResolveFilters;
+            this.disableTracking = disableTracking;
+            this.resolveDbContext = contextResolver.ResolveDbContext;
 
             keyNames = model.GetKeyNames();
 

--- a/src/GraphQL.EntityFramework/GraphApi/IDbContextResolver.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IDbContextResolver.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GraphQL.EntityFramework.GraphApi
+{
+    public interface IDbContextResolver<TDbContext> where TDbContext : DbContext
+    {
+        TDbContext ResolveDbContext(object userContext);
+    }
+}

--- a/src/GraphQL.EntityFramework/GraphApi/IFilterResolver.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IFilterResolver.cs
@@ -1,0 +1,7 @@
+namespace GraphQL.EntityFramework.GraphApi
+{
+    public interface IFilterResolver
+    {
+        public Filters.Filters? ResolveFilters(object userContext);
+    }
+}

--- a/src/GraphQL.EntityFramework/GraphApi/IFilterResolver.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/IFilterResolver.cs
@@ -2,6 +2,6 @@ namespace GraphQL.EntityFramework.GraphApi
 {
     public interface IFilterResolver
     {
-        public Filters.Filters? ResolveFilters(object userContext);
+        public Filters? ResolveFilters(object userContext);
     }
 }


### PR DESCRIPTION
…ter implementations as classes. In my implementation, I configure these via DI. For example, the DB Context is configured with logging that is itself configured by ASP.NET configuration. My filters have DB Contexts injected into them because they need to run additional queries. I am using filters as a way to perform post-query authorization checks and then remove entities that do not pass. The reason I am doing it this way is so that I can continue to use GraphQL.EntityFramework to dynamically build my queries.

#### Description

I would like it to be possible to inject the context resolver and filter implementations as classes. In my implementation, I configure these via DI. For example, the DB Context is configured with logging that is itself configured by ASP.NET configuration. My filters have DB Contexts injected into them because they need to run additional queries. I am using filters as a way to perform post-query authorization checks and then remove entities that do not pass. The reason I am doing it this way is so that I can continue to use `GraphQL.EntityFramework` to dynamically build my queries.

#### The solution

The solution is to add two interfaces `IDbContextResolver` and `IFilterResolver`. 

In my project, I have implemented these interfaces and inject them into the DI container. In the case of `IDbContextResolver`, it receives `DbContextOptions`. In the case of `IFilterResolver` it receives a set of Filter implementations that themselves receive `DbContext<T>` by DI.

Finally, I made `EfGraphQLConventions.RegisterScalarsAndArgs` public because I had to pull apart the way that the `EfGraphQLService` was getting constructed. 
