### PR TITLE
Globle swich off async

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,10 @@ public static void RegisterInContainer<TDbContext>(
         ResolveDbContext<TDbContext>? resolveDbContext = null,
         IModel? model = null,
         ResolveFilters? resolveFilters = null,
-        bool disableTracking = false)
+        bool disableTracking = false,
+        bool disableAsync = false)
 ```
-<sup><a href='/src/GraphQL.EntityFramework/EfGraphQLConventions.cs#L19-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-registerincontainer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/GraphQL.EntityFramework/EfGraphQLConventions.cs#L19-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-registerincontainer' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-registerincontainer-1'></a>
 ```cs
 EfGraphQLConventions.RegisterInContainer<MyDbContext>(
@@ -123,9 +124,10 @@ public static void RegisterInContainer<TDbContext>(
         ResolveDbContext<TDbContext>? resolveDbContext = null,
         IModel? model = null,
         ResolveFilters? resolveFilters = null,
-        bool disableTracking = false)
+        bool disableTracking = false,
+        bool disableAsync = false)
 ```
-<sup><a href='/src/GraphQL.EntityFramework/EfGraphQLConventions.cs#L19-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-registerincontainer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/GraphQL.EntityFramework/EfGraphQLConventions.cs#L19-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-registerincontainer' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-registerincontainer-1'></a>
 ```cs
 EfGraphQLConventions.RegisterInContainer<MyDbContext>(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,9 +112,7 @@ Setting `disableTracking` to true results in the use of `EntityFrameworkQueryabl
 The Include path 'DataItems->Section' results in a cycle.
 Cycles are not allowed in no-tracking queries; either use a tracking query or remove the cycle.
 ```
-#### DisableAsync
 
-Setting `disableAsync` to true will improve performance when reading large data (binary, text) from database. It is a known issue to read large data asynchronously in SqlClient. For more information please see:  https://github.com/dotnet/SqlClient/issues/593
 
 ### Usage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,7 +112,9 @@ Setting `disableTracking` to true results in the use of `EntityFrameworkQueryabl
 The Include path 'DataItems->Section' results in a cycle.
 Cycles are not allowed in no-tracking queries; either use a tracking query or remove the cycle.
 ```
+#### DisableAsync
 
+Setting `disableAsync` to true will improve performance when reading large data (binary, text) from database. It is a known issue to read large data asynchronously in SqlClient. For more information please see:  https://github.com/dotnet/SqlClient/issues/593
 
 ### Usage
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU5104;CS1573</NoWarn>
-    <Version>15.2.0</Version>
+    <Version>15.3.0-beta.1</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>EntityFrameworkCore, EntityFramework, GraphQL</PackageTags>
     <SignAssembly>false</SignAssembly>

--- a/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
+++ b/src/GraphQL.EntityFramework/EfGraphQLConventions.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Types.Relay;
+using GraphQL.Types.Relay;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +23,8 @@ public static class EfGraphQLConventions
             ResolveDbContext<TDbContext>? resolveDbContext = null,
             IModel? model = null,
             ResolveFilters? resolveFilters = null,
-            bool disableTracking = false)
+            bool disableTracking = false,
+            bool disableAsync = false)
 
         #endregion
 
@@ -33,7 +34,7 @@ public static class EfGraphQLConventions
         services.AddHttpContextAccessor();
         services.AddTransient<HttpContextCapture>();
         services.AddSingleton(
-            provider => Build(resolveDbContext, model, resolveFilters, provider, disableTracking));
+            provider => Build(resolveDbContext, model, resolveFilters, provider, disableTracking, disableAsync));
         services.AddSingleton<IEfGraphQLService<TDbContext>>(
             provider => provider.GetRequiredService<EfGraphQLService<TDbContext>>());
     }
@@ -43,7 +44,8 @@ public static class EfGraphQLConventions
         IModel? model,
         ResolveFilters? filters,
         IServiceProvider provider,
-        bool disableTracking)
+        bool disableTracking,
+        bool disableAsync)
         where TDbContext : DbContext
     {
         model ??= ResolveModel<TDbContext>(provider);
@@ -54,7 +56,8 @@ public static class EfGraphQLConventions
             model,
             dbContextResolver,
             filters,
-            disableTracking);
+            disableTracking,
+            disableAsync);
     }
 
     static TDbContext DbContextFromProvider<TDbContext>(IServiceProvider provider)

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace GraphQL.EntityFramework;
@@ -9,6 +9,7 @@ public partial class EfGraphQLService<TDbContext> :
 {
     ResolveFilters? resolveFilters;
     bool disableTracking;
+    bool disableAsync;
     ResolveDbContext<TDbContext> resolveDbContext;
     IReadOnlyDictionary<Type, List<string>> keyNames;
 
@@ -17,11 +18,12 @@ public partial class EfGraphQLService<TDbContext> :
         IModel model,
         ResolveDbContext<TDbContext> resolveDbContext,
         ResolveFilters? resolveFilters = null,
-        bool disableTracking = false)
+        bool disableTracking = false,
+        bool disableAsync = false)
     {
         this.resolveFilters = resolveFilters;
         this.disableTracking = disableTracking;
-
+        this.disableAsync = disableAsync;
         this.resolveDbContext = resolveDbContext;
 
         keyNames = model.GetKeyNames();

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Resolvers;
+using GraphQL.Resolvers;
 using GraphQL.Types;
 using Microsoft.EntityFrameworkCore;
 
@@ -70,8 +70,17 @@ partial class EfGraphQLService<TDbContext>
 
                     QueryLogger.Write(query);
 
-                    var list = await query
-                        .ToListAsync(context.CancellationToken);
+                    List<TReturn> list;
+                    if (disableAsync)
+                    {
+                        list = query.ToList();
+                    }
+                    else
+                    {
+                        list = await query
+                            .ToListAsync(context.CancellationToken);
+                    }
+
                     return await fieldContext.Filters.ApplyFilter(list, context.UserContext);
                 });
         }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Resolvers;
+using GraphQL.Resolvers;
 using GraphQL.Types;
 using Microsoft.EntityFrameworkCore;
 
@@ -93,7 +93,15 @@ partial class EfGraphQLService<TDbContext>
 
                     QueryLogger.Write(query);
 
-                    var single = await query.SingleOrDefaultAsync(context.CancellationToken);
+                    TReturn? single;
+                    if (disableAsync)
+                    {
+                        single = query.SingleOrDefault();
+                    }
+                    else
+                    {
+                        single = await query.SingleOrDefaultAsync(context.CancellationToken);
+                    }
 
                     if (single is not null)
                     {

--- a/src/Tests/IntegrationTests/IntegrationTests.Query_Large_Text_NoAsync.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Query_Large_Text_NoAsync.verified.txt
@@ -1,0 +1,33 @@
+﻿{
+  target:
+{
+  "data": {
+    "childEntities": [
+      {
+        "parent": {
+          "property": "Value1"
+        }
+      },
+      {
+        "parent": {
+          "property": "Value1"
+        }
+      },
+      {
+        "parent": {
+          "property": "Value4"
+        }
+      }
+    ]
+  }
+},
+  sql: [
+    {
+      Text:
+SELECT [c].[Id], [c].[Nullable], [c].[ParentId], [c].[Property], [p].[Id], [p].[Property]
+FROM [ChildEntities] AS [c]
+LEFT JOIN [ParentEntities] AS [p] ON [c].[ParentId] = [p].[Id]
+ORDER BY [c].[Property]
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_Found_Large_Text_NoAsync.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_Found_Large_Text_NoAsync.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  target:
+{
+  "data": {
+    "parentEntity": {
+      "id": "Guid_1"
+    }
+  }
+},
+  sql: [
+    {
+      Text:
+SELECT TOP(2) [p].[Id], [p].[Property]
+FROM [ParentEntities] AS [p]
+WHERE [p].[Id] = 'Guid_1'
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using EfLocalDb;
+using EfLocalDb;
 using GraphQL;
 using GraphQL.EntityFramework;
 using GraphQL.Types;
@@ -86,7 +86,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3 });
         Assert.NotNull(queryText);
     }
 
@@ -121,7 +121,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3 });
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -193,7 +193,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -333,7 +333,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -357,7 +357,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity2, entity1});
+        await RunQuery(database, query, null, null, false, new object[] { entity2, entity1 });
 
     }
 
@@ -382,7 +382,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -406,7 +406,7 @@ public partial class IntegrationTests
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -433,7 +433,7 @@ query ($value: String!)
 
         var inputs = new Inputs(new Dictionary<string, object?> { { "value", "value2" } });
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, inputs, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, inputs, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -457,7 +457,7 @@ query ($value: String!)
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -493,7 +493,33 @@ query ($value: String!)
             Property = "Value2"
         };
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, true, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, true, new object[] { entity1, entity2 });
+    }
+
+
+    [Fact]
+    public async Task Single_Found_Large_Text_NoAsync()
+    {
+        var query = @"
+{
+  parentEntity(id: ""00000000-0000-0000-0000-000000000001"") {
+id
+  }
+}";
+        var largeString = new StringBuilder().Append('a', 3 * 1024 * 1024);
+        var entity1 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Property = largeString.ToString()
+        };
+        var entity2 = new ParentEntity
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            Property = "Value2"
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 }, true);
     }
 
     [Fact]
@@ -539,7 +565,7 @@ query ($value: String!)
             Property = "Value2"
         };
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -575,7 +601,7 @@ query ($value: String!)
             Property = "Value2"
         };
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -621,7 +647,7 @@ mutation {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -667,7 +693,7 @@ mutation {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -719,7 +745,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -743,7 +769,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -767,7 +793,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact(Skip = "Work out how to eval server side")]
@@ -791,7 +817,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -816,7 +842,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -841,7 +867,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -873,7 +899,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3 });
     }
 
     [Fact]
@@ -897,7 +923,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact]
@@ -922,7 +948,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2 });
     }
 
     [Fact(Skip = "Work out why include is not used")]
@@ -977,7 +1003,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -1022,7 +1048,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact(Skip = "TODO")]
@@ -1046,7 +1072,7 @@ fragment childEntityFields on Child {
         level1.IncludeNonQueryableA = level2;
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {level1, level2});
+        await RunQuery(database, query, null, null, false, new object[] { level1, level2 });
     }
 
     [Fact(Skip = "fix order")]
@@ -1077,7 +1103,7 @@ fragment childEntityFields on Child {
         };
 
         var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {level1, level2, level3});
+        await RunQuery(database, query, null, null, false, new object[] { level1, level2, level3 });
     }
 
     [Fact]
@@ -1111,7 +1137,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {level1, level2, level3});
+        await RunQuery(database, query, null, null, false, new object[] { level1, level2, level3 });
     }
 
     [Fact]
@@ -1152,7 +1178,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {level1b, level2b, level1a, level2a, level3a});
+        await RunQuery(database, query, null, null, false, new object[] { level1b, level2b, level1a, level2a, level3a });
     }
 
     [Fact]
@@ -1206,7 +1232,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -1252,7 +1278,53 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, true, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, true, new object[] { entity1, entity2, entity3, entity4, entity5 });
+    }
+
+
+    [Fact]
+    public async Task Query_Large_Text_NoAsync()
+    {
+        var query = @"
+{
+  childEntities (orderBy: {path: ""property""})
+  {
+    parent
+    {
+      property
+    }
+  }
+}";
+        var largeString = new StringBuilder().Append('a', 3 * 1024 * 1024);
+        var entity1 = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var entity2 = new ChildEntity
+        {
+            Property = largeString.ToString(),
+            Parent = entity1
+        };
+        var entity3 = new ChildEntity
+        {
+            Property = "Value3",
+            Parent = entity1
+        };
+        entity1.Children.Add(entity2);
+        entity1.Children.Add(entity3);
+        var entity4 = new ParentEntity
+        {
+            Property = "Value4"
+        };
+        var entity5 = new ChildEntity
+        {
+            Property = "Value5",
+            Parent = entity4
+        };
+        entity4.Children.Add(entity5);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 }, true);
     }
 
     [Fact]
@@ -1298,7 +1370,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -1339,7 +1411,7 @@ fragment childEntityFields on Child {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity5 });
     }
 
     [Fact(Skip = "fix order")]
@@ -1375,7 +1447,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact(Skip = "fix order")]
@@ -1421,7 +1493,7 @@ fragment childEntityFields on Child {
         entity4.Children.Add(entity5);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {entity1, entity2, entity3, entity4, entity5});
+        await RunQuery(database, query, null, null, false, new object[] { entity1, entity2, entity3, entity4, entity5 });
     }
 
     [Fact]
@@ -1451,7 +1523,7 @@ fragment childEntityFields on Child {
         parent.Child2 = child2;
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {parent, child1, child2});
+        await RunQuery(database, query, null, null, false, new object[] { parent, child1, child2 });
     }
 
     [Fact(Skip = "Broke with gql 4")]
@@ -1523,7 +1595,7 @@ fragment childEntityFields on DerivedChild {
         derivedEntity2.Children.Add(childEntity4);
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {derivedEntity1, childEntity1, childEntity2, derivedEntity2, childEntity3, childEntity4});
+        await RunQuery(database, query, null, null, false, new object[] { derivedEntity1, childEntity1, childEntity2, derivedEntity2, childEntity3, childEntity4 });
     }
 
     [Fact]
@@ -1576,7 +1648,7 @@ fragment childEntityFields on DerivedChild {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {middle11, middle12, middle21});
+        await RunQuery(database, query, null, null, false, new object[] { middle11, middle12, middle21 });
     }
 
     [Fact]
@@ -1629,7 +1701,7 @@ fragment childEntityFields on DerivedChild {
         };
 
         await using var database = await sqlInstance.Build();
-        await RunQuery(database, query, null, null, false, new object[] {middle11, middle12, middle21});
+        await RunQuery(database, query, null, null, false, new object[] { middle11, middle12, middle21 });
     }
 
     static async Task RunQuery(
@@ -1639,6 +1711,7 @@ fragment childEntityFields on DerivedChild {
         Filters? filters,
         bool disableTracking,
         object[] entities,
+        bool disableAsync = false,
         [CallerFilePath] string sourceFile = "")
     {
         var dbContext = database.Context;
@@ -1657,7 +1730,7 @@ fragment childEntityFields on DerivedChild {
         SqlRecording.StartRecording();
         try
         {
-            var result = await QueryExecutor.ExecuteQuery(query, services, context, inputs, filters, disableTracking);
+            var result = await QueryExecutor.ExecuteQuery(query, services, context, inputs, filters, disableTracking, disableAsync);
             await Verify(result, sourceFile: sourceFile).ScrubInlineGuids();
         }
         catch (ExecutionError executionError)

--- a/src/Tests/IntegrationTests/QueryExecutor.cs
+++ b/src/Tests/IntegrationTests/QueryExecutor.cs
@@ -11,7 +11,8 @@ static class QueryExecutor
         TDbContext data,
         Inputs? inputs,
         Filters? filters,
-        bool disableTracking)
+        bool disableTracking,
+        bool disableAsync)
         where TDbContext : DbContext
     {
         query = query.Replace("'", "\"");
@@ -20,7 +21,8 @@ static class QueryExecutor
             _ => data,
             data.Model,
             _ => filters,
-            disableTracking);
+            disableTracking,
+            disableAsync);
         EfGraphQLConventions.RegisterConnectionTypesInContainer(services);
         await using var provider = services.BuildServiceProvider();
         using var schema = new Schema(provider);


### PR DESCRIPTION
Where it is clear the below content has not read, the issue is likely to be closed with "please read the template". Please don't take offense at this. It is simply a time management decision. When someone raises an issue, without reading the template, then often too much time is spent going back and forth to obtain information that is outlined below.


#### You should already be a Patron

To be using this project you should be a [Patron](https://opencollective.com/graphqlentityframework/order/8286). See [Licensing/Patron FAQ](https://github.com/SimonCropp/graphqlentityframework/blob/master/docs/licensing-patron-faq.md). With that in mind, it is assumed anyone raising a PR is already a Patron. As such your GitHub Id may be verified against the [OpenCollective contributors](https://opencollective.com/graphqlentityframework#contributors). This process will depend on the PR quality, your circumstances, and the impact on the larger user base.


#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.


#### Description

Reading large data (binary, text) asynchronously is extremely slow, this is a known issue in SQLClient, see below link:
https://github.com/dotnet/SqlClient/issues/593

#### The solution

Provide option to switch off async globally so to improve the reading speed.


#### Todos

 