### PR TITLE
Breaking: Infer type arguments for projection-based FieldBuilder APIs

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -153,10 +153,12 @@ The library supports EF projections where you can use `Select()` to project to D
 The library provides projection-based extension methods on `FieldBuilder` to safely access navigation properties in custom resolvers:
 
 **Extension Methods** (`src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs`)
-- `Resolve<TDbContext, TSource, TReturn, TProjection>()` - Synchronous resolver with projection
-- `ResolveAsync<TDbContext, TSource, TReturn, TProjection>()` - Async resolver with projection
-- `ResolveList<TDbContext, TSource, TReturn, TProjection>()` - List resolver with projection
-- `ResolveListAsync<TDbContext, TSource, TReturn, TProjection>()` - Async list resolver with projection
+- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
+- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
+- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+
+All type arguments are inferred. `TDbContext` comes from the `IEfGraphQLService<TDbContext>` argument (the `GraphQlService` property inside an `EfObjectGraphType`), which is also used at execution time to resolve the `DbContext` and filters.
 
 **Why Use These Methods:**
 When using `Field().Resolve()` or `Field().ResolveAsync()` directly, navigation properties on `context.Source` may be null if the projection system didn't include them. The projection-based extension methods ensure required data is loaded by:
@@ -171,9 +173,10 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
 {
     public ChildGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) : base(graphQlService) =>
         Field<int>("ParentId")
-            .Resolve<IntegrationDbContext, ChildEntity, int, ParentEntity>(
-                projection: x => x.Parent!,
-                resolve: ctx => ctx.Projection.Id);
+            .Resolve(
+                graphQlService,
+                projection: _ => _.Parent!,
+                resolve: _ => _.Projection.Id);
 }
 ```
 

--- a/claude.md
+++ b/claude.md
@@ -152,13 +152,11 @@ The library supports EF projections where you can use `Select()` to project to D
 
 The library provides projection-based extension methods on `FieldBuilder` to safely access navigation properties in custom resolvers:
 
-**Extension Methods** (`src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs`)
-- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
-- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
-- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
-- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+**Methods**
+- `Resolve(projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(projection, resolve)` - Async resolver with projection
 
-All type arguments are inferred. `TDbContext` comes from the `IEfGraphQLService<TDbContext>` argument (the `GraphQlService` property inside an `EfObjectGraphType`), which is also used at execution time to resolve the `DbContext` and filters.
+Inside `EfObjectGraphType` and `EfInterfaceGraphType`, the `Field` methods return `EfFieldBuilder<TDbContext, TSource, TReturn>` (`src/GraphQL.EntityFramework/GraphApi/EfFieldBuilder.cs`), which carries the `IEfGraphQLService<TDbContext>` and exposes these as instance methods with only `TProjection` inferred. Its fluent methods are overridden to keep returning `EfFieldBuilder`. Equivalent extension methods on `FieldBuilder` (`Resolve`, `ResolveAsync`, `ResolveList`, `ResolveListAsync`) take the service as their first argument, for plain graph types and list results.
 
 **Why Use These Methods:**
 When using `Field().Resolve()` or `Field().ResolveAsync()` directly, navigation properties on `context.Source` may be null if the projection system didn't include them. The projection-based extension methods ensure required data is loaded by:
@@ -174,7 +172,6 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
     public ChildGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) : base(graphQlService) =>
         Field<int>("ParentId")
             .Resolve(
-                graphQlService,
                 projection: _ => _.Parent!,
                 resolve: _ => _.Projection.Id);
 }

--- a/docs/defining-graphs.md
+++ b/docs/defining-graphs.md
@@ -174,7 +174,7 @@ Without automatic foreign key inclusion, `context.Source.CustomerId` would be `0
 
 ### Using Projection-Based Resolve
 
-When using `Field().Resolve()` or `Field().ResolveAsync()` in graph types, navigation properties on `context.Source` may not be loaded if the projection system didn't include them. To safely access navigation properties in custom resolvers, use the projection-based extension methods:
+When using `Field().Resolve()` or `Field().ResolveAsync()` in graph types, navigation properties on `context.Source` may not be loaded if the projection system didn't include them. To safely access navigation properties in custom resolvers, use the projection-based resolve methods:
 
 ```cs
 public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntity>
@@ -183,20 +183,21 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
         base(graphQlService) =>
         Field<int>("ParentId")
             .Resolve(
-                graphQlService,
                 projection: _ => _.Parent,
                 resolve: _ => _.Projection.Id);
 }
 ```
 
-**Available Extension Methods:**
+**Available Methods:**
 
-- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
-- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
-- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
-- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+Inside an `EfObjectGraphType` or `EfInterfaceGraphType`, the `Field` methods return an `EfFieldBuilder<TDbContext, TSource, TReturn>` that already knows the `IEfGraphQLService<TDbContext>`. It adds:
 
-All type arguments are inferred: `TSource` and `TReturn` from the field builder, `TDbContext` from the `IEfGraphQLService<TDbContext>` argument, and `TProjection` from the projection expression. The service is used at execution time to resolve the `DbContext` and filters. Inside an `EfObjectGraphType` it is available as the `GraphQlService` property.
+- `Resolve(projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(projection, resolve)` - Async resolver with projection
+
+Only `TProjection` is inferred, from the projection expression; the other type arguments come from the graph type. The builder's fluent methods (`Description`, `Argument`, `Configure`, etc.) are overridden to keep returning `EfFieldBuilder`, so the projection-based methods remain available anywhere in the chain. Extension methods from other libraries return the base `FieldBuilder`, so call those after the projection-based resolve.
+
+For a plain `ObjectGraphType`, or for the list variants, the equivalent extension methods on `FieldBuilder` take the service as their first argument: `Resolve(graphQlService, projection, resolve)`, `ResolveAsync(...)`, `ResolveList(...)` and `ResolveListAsync(...)`. The service is used at execution time to resolve the `DbContext` and filters.
 
 The projection-based extension methods ensure required data is loaded by:
 
@@ -217,7 +218,6 @@ Field<int>("ParentId")
 ```cs
 Field<int>("ParentId")
     .Resolve(
-        graphQlService,
         projection: _ => _.Parent,
         resolve: _ => _.Projection.Id); // Parent is guaranteed to be loaded
 ```

--- a/docs/defining-graphs.md
+++ b/docs/defining-graphs.md
@@ -182,18 +182,21 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
     public ChildGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) :
         base(graphQlService) =>
         Field<int>("ParentId")
-            .Resolve<IntegrationDbContext, ChildEntity, int, ParentEntity>(
-                projection: x => x.Parent,
-                resolve: ctx => ctx.Projection.Id);
+            .Resolve(
+                graphQlService,
+                projection: _ => _.Parent,
+                resolve: _ => _.Projection.Id);
 }
 ```
 
 **Available Extension Methods:**
 
-- `Resolve<TDbContext, TSource, TReturn, TProjection>()` - Synchronous resolver with projection
-- `ResolveAsync<TDbContext, TSource, TReturn, TProjection>()` - Async resolver with projection
-- `ResolveList<TDbContext, TSource, TReturn, TProjection>()` - List resolver with projection
-- `ResolveListAsync<TDbContext, TSource, TReturn, TProjection>()` - Async list resolver with projection
+- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
+- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
+- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+
+All type arguments are inferred: `TSource` and `TReturn` from the field builder, `TDbContext` from the `IEfGraphQLService<TDbContext>` argument, and `TProjection` from the projection expression. The service is used at execution time to resolve the `DbContext` and filters. Inside an `EfObjectGraphType` it is available as the `GraphQlService` property.
 
 The projection-based extension methods ensure required data is loaded by:
 
@@ -213,9 +216,10 @@ Field<int>("ParentId")
 
 ```cs
 Field<int>("ParentId")
-    .Resolve<IntegrationDbContext, ChildEntity, int, ParentEntity>(
-        projection: x => x.Parent,
-        resolve: ctx => ctx.Projection.Id); // Parent is guaranteed to be loaded
+    .Resolve(
+        graphQlService,
+        projection: _ => _.Parent,
+        resolve: _ => _.Projection.Id); // Parent is guaranteed to be loaded
 ```
 
 **Note:** A Roslyn analyzer (GQLEF002) warns at compile time when `Field().Resolve()` accesses properties other than primary keys and foreign keys. Only PK and FK properties are guaranteed to be loaded by the projection system - all other properties (including regular scalars like `Name`) require projection-based extension methods to ensure they are loaded.
@@ -231,8 +235,7 @@ This is useful for computed or permission-check fields that read from `context.S
 // The parent query's SELECT projection will include Status,
 // even if the client doesn't explicitly request a "status" field.
 Field<NonNullGraphType<StringGraphType>, string>("statusLabel")
-    .WithProjection(
-        (Expression<Func<OrderEntity, OrderStatus>>)(_ => _.Status))
+    .WithProjection(_ => _.Status)
     .Resolve(context => context.Source.Status switch
     {
         OrderStatus.Active => "Active",

--- a/docs/mdsource/defining-graphs.source.md
+++ b/docs/mdsource/defining-graphs.source.md
@@ -119,18 +119,21 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
     public ChildGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) :
         base(graphQlService) =>
         Field<int>("ParentId")
-            .Resolve<IntegrationDbContext, ChildEntity, int, ParentEntity>(
-                projection: x => x.Parent,
-                resolve: ctx => ctx.Projection.Id);
+            .Resolve(
+                graphQlService,
+                projection: _ => _.Parent,
+                resolve: _ => _.Projection.Id);
 }
 ```
 
 **Available Extension Methods:**
 
-- `Resolve<TDbContext, TSource, TReturn, TProjection>()` - Synchronous resolver with projection
-- `ResolveAsync<TDbContext, TSource, TReturn, TProjection>()` - Async resolver with projection
-- `ResolveList<TDbContext, TSource, TReturn, TProjection>()` - List resolver with projection
-- `ResolveListAsync<TDbContext, TSource, TReturn, TProjection>()` - Async list resolver with projection
+- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
+- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
+- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+
+All type arguments are inferred: `TSource` and `TReturn` from the field builder, `TDbContext` from the `IEfGraphQLService<TDbContext>` argument, and `TProjection` from the projection expression. The service is used at execution time to resolve the `DbContext` and filters. Inside an `EfObjectGraphType` it is available as the `GraphQlService` property.
 
 The projection-based extension methods ensure required data is loaded by:
 
@@ -150,9 +153,10 @@ Field<int>("ParentId")
 
 ```cs
 Field<int>("ParentId")
-    .Resolve<IntegrationDbContext, ChildEntity, int, ParentEntity>(
-        projection: x => x.Parent,
-        resolve: ctx => ctx.Projection.Id); // Parent is guaranteed to be loaded
+    .Resolve(
+        graphQlService,
+        projection: _ => _.Parent,
+        resolve: _ => _.Projection.Id); // Parent is guaranteed to be loaded
 ```
 
 **Note:** A Roslyn analyzer (GQLEF002) warns at compile time when `Field().Resolve()` accesses properties other than primary keys and foreign keys. Only PK and FK properties are guaranteed to be loaded by the projection system - all other properties (including regular scalars like `Name`) require projection-based extension methods to ensure they are loaded.
@@ -168,8 +172,7 @@ This is useful for computed or permission-check fields that read from `context.S
 // The parent query's SELECT projection will include Status,
 // even if the client doesn't explicitly request a "status" field.
 Field<NonNullGraphType<StringGraphType>, string>("statusLabel")
-    .WithProjection(
-        (Expression<Func<OrderEntity, OrderStatus>>)(_ => _.Status))
+    .WithProjection(_ => _.Status)
     .Resolve(context => context.Source.Status switch
     {
         OrderStatus.Active => "Active",

--- a/docs/mdsource/defining-graphs.source.md
+++ b/docs/mdsource/defining-graphs.source.md
@@ -111,7 +111,7 @@ Without automatic foreign key inclusion, `context.Source.CustomerId` would be `0
 
 ### Using Projection-Based Resolve
 
-When using `Field().Resolve()` or `Field().ResolveAsync()` in graph types, navigation properties on `context.Source` may not be loaded if the projection system didn't include them. To safely access navigation properties in custom resolvers, use the projection-based extension methods:
+When using `Field().Resolve()` or `Field().ResolveAsync()` in graph types, navigation properties on `context.Source` may not be loaded if the projection system didn't include them. To safely access navigation properties in custom resolvers, use the projection-based resolve methods:
 
 ```cs
 public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntity>
@@ -120,20 +120,21 @@ public class ChildGraphType : EfObjectGraphType<IntegrationDbContext, ChildEntit
         base(graphQlService) =>
         Field<int>("ParentId")
             .Resolve(
-                graphQlService,
                 projection: _ => _.Parent,
                 resolve: _ => _.Projection.Id);
 }
 ```
 
-**Available Extension Methods:**
+**Available Methods:**
 
-- `Resolve(graphQlService, projection, resolve)` - Synchronous resolver with projection
-- `ResolveAsync(graphQlService, projection, resolve)` - Async resolver with projection
-- `ResolveList(graphQlService, projection, resolve)` - List resolver with projection
-- `ResolveListAsync(graphQlService, projection, resolve)` - Async list resolver with projection
+Inside an `EfObjectGraphType` or `EfInterfaceGraphType`, the `Field` methods return an `EfFieldBuilder<TDbContext, TSource, TReturn>` that already knows the `IEfGraphQLService<TDbContext>`. It adds:
 
-All type arguments are inferred: `TSource` and `TReturn` from the field builder, `TDbContext` from the `IEfGraphQLService<TDbContext>` argument, and `TProjection` from the projection expression. The service is used at execution time to resolve the `DbContext` and filters. Inside an `EfObjectGraphType` it is available as the `GraphQlService` property.
+- `Resolve(projection, resolve)` - Synchronous resolver with projection
+- `ResolveAsync(projection, resolve)` - Async resolver with projection
+
+Only `TProjection` is inferred, from the projection expression; the other type arguments come from the graph type. The builder's fluent methods (`Description`, `Argument`, `Configure`, etc.) are overridden to keep returning `EfFieldBuilder`, so the projection-based methods remain available anywhere in the chain. Extension methods from other libraries return the base `FieldBuilder`, so call those after the projection-based resolve.
+
+For a plain `ObjectGraphType`, or for the list variants, the equivalent extension methods on `FieldBuilder` take the service as their first argument: `Resolve(graphQlService, projection, resolve)`, `ResolveAsync(...)`, `ResolveList(...)` and `ResolveListAsync(...)`. The service is used at execution time to resolve the `DbContext` and filters.
 
 The projection-based extension methods ensure required data is loaded by:
 
@@ -154,7 +155,6 @@ Field<int>("ParentId")
 ```cs
 Field<int>("ParentId")
     .Resolve(
-        graphQlService,
         projection: _ => _.Parent,
         resolve: _ => _.Projection.Id); // Parent is guaranteed to be loaded
 ```

--- a/src/GraphQL.EntityFramework.Analyzers.Tests/FieldBuilderResolveAnalyzerTests.cs
+++ b/src/GraphQL.EntityFramework.Analyzers.Tests/FieldBuilderResolveAnalyzerTests.cs
@@ -227,7 +227,6 @@ public class FieldBuilderResolveAnalyzerTests
                 {
                     Field<string>("ParentName")
                         .Resolve(
-                            graphQlService,
                             projection: _ => _.Parent,
                             resolve: _ => _.Projection.Name);
                 }
@@ -267,7 +266,6 @@ public class FieldBuilderResolveAnalyzerTests
                 {
                     Field<string>("ParentName")
                         .ResolveAsync(
-                            graphQlService,
                             projection: _ => _.Parent,
                             resolve: async ctx => await Task.FromResult(ctx.Projection.Name));
                 }
@@ -499,7 +497,6 @@ public class FieldBuilderResolveAnalyzerTests
                 {
                     Field<int>("ParentId")
                         .Resolve(
-                            graphQlService,
                             projection: _ => _,
                             resolve: _ => _.Projection.ParentId);
                 }
@@ -536,7 +533,6 @@ public class FieldBuilderResolveAnalyzerTests
                 {
                     Field<int>("ParentId")
                         .ResolveAsync(
-                            graphQlService,
                             _ => _,
                             _ => Task.FromResult(_.Projection.ParentId));
                 }

--- a/src/GraphQL.EntityFramework.Analyzers.Tests/FieldBuilderResolveAnalyzerTests.cs
+++ b/src/GraphQL.EntityFramework.Analyzers.Tests/FieldBuilderResolveAnalyzerTests.cs
@@ -226,7 +226,8 @@ public class FieldBuilderResolveAnalyzerTests
                 public ChildGraphType(IEfGraphQLService<TestDbContext> graphQlService) : base(graphQlService)
                 {
                     Field<string>("ParentName")
-                        .Resolve<TestDbContext, ChildEntity, string, ParentEntity>(
+                        .Resolve(
+                            graphQlService,
                             projection: _ => _.Parent,
                             resolve: _ => _.Projection.Name);
                 }
@@ -265,7 +266,8 @@ public class FieldBuilderResolveAnalyzerTests
                 public ChildGraphType(IEfGraphQLService<TestDbContext> graphQlService) : base(graphQlService)
                 {
                     Field<string>("ParentName")
-                        .ResolveAsync<TestDbContext, ChildEntity, string, ParentEntity>(
+                        .ResolveAsync(
+                            graphQlService,
                             projection: _ => _.Parent,
                             resolve: async ctx => await Task.FromResult(ctx.Projection.Name));
                 }
@@ -473,10 +475,78 @@ public class FieldBuilderResolveAnalyzerTests
         Assert.Equal("GQLEF002", diagnostics[0].Id);
     }
 
-    // NOTE: Analyzer tests for GQLEF003 (identity projection detection) are skipped
-    // because the analyzer implementation has issues detecting identity projections in test scenarios.
-    // However, runtime validation works perfectly and catches identity projections immediately when code runs.
-    // See FieldBuilderExtensionsTests for runtime validation tests.
+    [Fact]
+    public async Task DetectsIdentityProjectionInProjectionBasedResolve()
+    {
+        var source = """
+            using GraphQL.EntityFramework;
+            using GraphQL.Types;
+            using Microsoft.EntityFrameworkCore;
+
+            public class ParentEntity { public int Id { get; set; } }
+            public class ChildEntity
+            {
+                public int Id { get; set; }
+                public int ParentId { get; set; }
+                public ParentEntity Parent { get; set; } = null!;
+            }
+
+            public class TestDbContext : DbContext { }
+
+            public class ChildGraphType : EfObjectGraphType<TestDbContext, ChildEntity>
+            {
+                public ChildGraphType(IEfGraphQLService<TestDbContext> graphQlService) : base(graphQlService)
+                {
+                    Field<int>("ParentId")
+                        .Resolve(
+                            graphQlService,
+                            projection: _ => _,
+                            resolve: _ => _.Projection.ParentId);
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Single(diagnostics);
+        Assert.Equal("GQLEF003", diagnostics[0].Id);
+    }
+
+    [Fact]
+    public async Task DetectsIdentityProjectionInProjectionBasedResolveAsyncWithPositionalArguments()
+    {
+        var source = """
+            using GraphQL.EntityFramework;
+            using GraphQL.Types;
+            using Microsoft.EntityFrameworkCore;
+            using System.Threading.Tasks;
+
+            public class ParentEntity { public int Id { get; set; } }
+            public class ChildEntity
+            {
+                public int Id { get; set; }
+                public int ParentId { get; set; }
+                public ParentEntity Parent { get; set; } = null!;
+            }
+
+            public class TestDbContext : DbContext { }
+
+            public class ChildGraphType : EfObjectGraphType<TestDbContext, ChildEntity>
+            {
+                public ChildGraphType(IEfGraphQLService<TestDbContext> graphQlService) : base(graphQlService)
+                {
+                    Field<int>("ParentId")
+                        .ResolveAsync(
+                            graphQlService,
+                            _ => _,
+                            _ => Task.FromResult(_.Projection.ParentId));
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Single(diagnostics);
+        Assert.Equal("GQLEF003", diagnostics[0].Id);
+    }
 
     static async Task<Diagnostic[]> GetDiagnosticsAsync(string source)
     {
@@ -548,7 +618,9 @@ public class FieldBuilderResolveAnalyzerTests
         var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync();
 
         // Check for compilation errors
-        var compilationErrors = allDiagnostics.Where(_ => _.Severity == DiagnosticSeverity.Error).ToArray();
+        var compilationErrors = allDiagnostics
+            .Where(_ => _.Severity == DiagnosticSeverity.Error && !_.Id.StartsWith("GQLEF"))
+            .ToArray();
         if (compilationErrors.Length > 0)
         {
             var errorMessages = string.Join("\n", compilationErrors.Select(_ => $"{_.Id}: {_.GetMessage()}"));

--- a/src/GraphQL.EntityFramework.Analyzers/DiagnosticDescriptors.cs
+++ b/src/GraphQL.EntityFramework.Analyzers/DiagnosticDescriptors.cs
@@ -7,7 +7,7 @@ public static class DiagnosticDescriptors
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "When using Field().Resolve() or Field().ResolveAsync() inside EfObjectGraphType, EfInterfaceGraphType, or QueryGraphType classes, navigation properties on context.Source may not be loaded due to EF projection. Use the projection-based extension methods (Resolve<TDbContext, TSource, TReturn, TProjection>, ResolveAsync<TDbContext, TSource, TReturn, TProjection>, etc.) to ensure required data is loaded.",
+        description: "When using Field().Resolve() or Field().ResolveAsync() inside EfObjectGraphType, EfInterfaceGraphType, or QueryGraphType classes, navigation properties on context.Source may not be loaded due to EF projection. Use the projection-based extension methods (Resolve, ResolveAsync, ResolveList, ResolveListAsync with a projection argument) to ensure required data is loaded.",
         helpLinkUri: "https://github.com/SimonCropp/GraphQL.EntityFramework#projection-based-resolve");
 
     public static readonly DiagnosticDescriptor GQLEF003 = new(

--- a/src/GraphQL.EntityFramework.Analyzers/FieldBuilderResolveAnalyzer.cs
+++ b/src/GraphQL.EntityFramework.Analyzers/FieldBuilderResolveAnalyzer.cs
@@ -88,14 +88,9 @@ public class FieldBuilderResolveAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Check if the containing type is FieldBuilder<,>
-        var containingType = methodSymbol.ContainingType;
-        if (containingType == null)
-        {
-            return false;
-        }
-
-        var baseType = containingType;
+        // The receiver is FieldBuilder<,> both for its instance methods and for the
+        // projection-based extension methods, where it is the `this` parameter type
+        var baseType = GetReceiverType(methodSymbol);
         while (baseType != null)
         {
             if (baseType.Name == "FieldBuilder" &&
@@ -118,6 +113,23 @@ public class FieldBuilderResolveAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    static ITypeSymbol? GetReceiverType(IMethodSymbol method)
+    {
+        if (!method.IsExtensionMethod)
+        {
+            return method.ContainingType;
+        }
+
+        // Reduced form: builder.Resolve(...)
+        if (method.ReducedFrom != null)
+        {
+            return method.ReceiverType;
+        }
+
+        // Static form: FieldBuilderExtensions.Resolve(builder, ...)
+        return method.Parameters.FirstOrDefault()?.Type;
     }
 
     static bool IsProjectionBasedResolve(InvocationExpressionSyntax invocation, SemanticModel semanticModel)

--- a/src/GraphQL.EntityFramework.Analyzers/FieldBuilderResolveAnalyzer.cs
+++ b/src/GraphQL.EntityFramework.Analyzers/FieldBuilderResolveAnalyzer.cs
@@ -29,7 +29,7 @@ public class FieldBuilderResolveAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if the lambda already uses projection-based extension methods (has 4 type parameters)
+        // Check if the lambda already uses projection-based extension methods (has a projection parameter)
         var isProjectionBased = IsProjectionBasedResolve(invocation, context.SemanticModel);
 
         if (isProjectionBased)
@@ -140,11 +140,9 @@ public class FieldBuilderResolveAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Projection-based extension methods have 4 type parameters:
-        // TDbContext, TSource, TReturn, TProjection
-        // AND have a parameter named "projection"
-        return methodSymbol.TypeArguments.Length == 4 &&
-               methodSymbol.Parameters.Any(_ => _.Name == "projection") &&
+        // Projection-based methods (extension methods on FieldBuilder and instance
+        // methods on EfFieldBuilder) are identified by their "projection" parameter
+        return methodSymbol.Parameters.Any(_ => _.Name == "projection") &&
                methodSymbol.ContainingNamespace?.ToString() == "GraphQL.EntityFramework";
     }
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfFieldBuilder.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfFieldBuilder.cs
@@ -1,0 +1,215 @@
+using GraphQL.Instrumentation;
+using GraphQL.Validation;
+
+namespace GraphQL.EntityFramework;
+
+/// <summary>
+/// A <see cref="FieldBuilder{TSourceType, TReturnType}"/> that carries the <see cref="IEfGraphQLService{TDbContext}"/>,
+/// so projection-based resolvers can be configured without passing the service.
+/// Returned by the Field methods of <see cref="EfObjectGraphType{TDbContext, TSource}"/>
+/// and <see cref="EfInterfaceGraphType{TDbContext, TSource}"/>.
+/// The fluent methods are overridden to return this type so the projection-based
+/// methods remain available anywhere in a chain.
+/// </summary>
+public class EfFieldBuilder<TDbContext, TSource, TReturn>(FieldType fieldType, IEfGraphQLService<TDbContext> graphQlService) :
+    FieldBuilder<TSource, TReturn>(fieldType)
+    where TDbContext : DbContext
+{
+    public IEfGraphQLService<TDbContext> GraphQlService { get; } = graphQlService;
+
+    /// <summary>
+    /// Resolves field value using a projection to ensure required data is loaded.
+    /// </summary>
+    /// <typeparam name="TProjection">The projected data type</typeparam>
+    /// <param name="projection">Expression to project required data from source</param>
+    /// <param name="resolve">Function to resolve field value from projected data</param>
+    public EfFieldBuilder<TDbContext, TSource, TReturn> Resolve<TProjection>(
+        Expression<Func<TSource, TProjection>> projection,
+        Func<ResolveProjectionContext<TDbContext, TProjection>, TReturn> resolve)
+    {
+        FieldBuilderExtensions.Resolve(this, GraphQlService, projection, resolve);
+        return this;
+    }
+
+    /// <summary>
+    /// Resolves field value asynchronously using a projection to ensure required data is loaded.
+    /// </summary>
+    /// <typeparam name="TProjection">The projected data type</typeparam>
+    /// <param name="projection">Expression to project required data from source</param>
+    /// <param name="resolve">Async function to resolve field value from projected data</param>
+    public EfFieldBuilder<TDbContext, TSource, TReturn> ResolveAsync<TProjection>(
+        Expression<Func<TSource, TProjection>> projection,
+        Func<ResolveProjectionContext<TDbContext, TProjection>, Task<TReturn>> resolve)
+    {
+        FieldBuilderExtensions.ResolveAsync(this, GraphQlService, projection, resolve);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Type(IGraphType type)
+    {
+        base.Type(type);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Description(string? description)
+    {
+        base.Description(description);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> DeprecationReason(string? deprecationReason)
+    {
+        base.DeprecationReason(deprecationReason);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> DefaultValue(TReturn? defaultValue = default)
+    {
+        base.DefaultValue(defaultValue);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ParseValue(Func<object, object> parseValue)
+    {
+        base.ParseValue(parseValue);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Validate(Action<object> validation)
+    {
+        base.Validate(validation);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ValidateArguments(Action<FieldArgumentsValidationContext> validation)
+    {
+        base.ValidateArguments(validation);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ValidateArguments(Func<FieldArgumentsValidationContext, ValueTask> validation)
+    {
+        base.ValidateArguments(validation);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Resolve(IFieldResolver? resolver)
+    {
+        base.Resolve(resolver);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Resolve(Func<IResolveFieldContext<TSource>, TReturn?> resolve)
+    {
+        base.Resolve(resolve);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ResolveAsync(Func<IResolveFieldContext<TSource>, Task<TReturn?>> resolve)
+    {
+        base.ResolveAsync(resolve);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ResolveDelegate(Delegate? resolve)
+    {
+        base.ResolveDelegate(resolve);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
+    {
+        base.Argument<TArgumentGraphType>(name, description, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument<TArgumentGraphType>(string name)
+    {
+        base.Argument<TArgumentGraphType>(name);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
+    {
+        base.Argument<TArgumentGraphType>(name, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument<TArgumentClrType>(string name, bool nullable = false, Action<QueryArgument>? configure = null)
+    {
+        base.Argument<TArgumentClrType>(name, nullable, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument<TArgumentClrType>(string name, bool nullable, string? description, Action<QueryArgument>? configure = null)
+    {
+        base.Argument<TArgumentClrType>(name, nullable, description, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument(Type type, string name, Action<QueryArgument>? configure = null)
+    {
+        base.Argument(type, name, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Argument(IGraphType type, string name, Action<QueryArgument>? configure = null)
+    {
+        base.Argument(type, name, configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Arguments(IEnumerable<QueryArgument> arguments)
+    {
+        base.Arguments(arguments);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Arguments(params QueryArgument[] arguments)
+    {
+        base.Arguments(arguments);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> Configure(Action<FieldType> configure)
+    {
+        base.Configure(configure);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ResolveStream(Func<IResolveFieldContext<TSource>, IObservable<TReturn?>> sourceStreamResolver)
+    {
+        base.ResolveStream(sourceStreamResolver);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ResolveStreamAsync(Func<IResolveFieldContext<TSource>, Task<IObservable<TReturn?>>> sourceStreamResolver)
+    {
+        base.ResolveStreamAsync(sourceStreamResolver);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> DependsOn<TService>()
+    {
+        base.DependsOn<TService>();
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ApplyMiddleware(IFieldMiddleware middleware)
+    {
+        base.ApplyMiddleware(middleware);
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ApplyMiddleware<TMiddleware>()
+    {
+        base.ApplyMiddleware<TMiddleware>();
+        return this;
+    }
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturn> ApplyMiddleware(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+    {
+        base.ApplyMiddleware(middleware);
+        return this;
+    }
+}

--- a/src/GraphQL.EntityFramework/GraphApi/EfInterfaceGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfInterfaceGraphType.cs
@@ -12,6 +12,44 @@ public class EfInterfaceGraphType<TDbContext, TSource>(
 
     public IEfGraphQLService<TDbContext> GraphQlService { get; } = graphQlService;
 
+    // The Field methods return an EfFieldBuilder so projection-based resolvers
+    // can be configured without passing the service
+    public override EfFieldBuilder<TDbContext, TSource, TReturnType> Field<TGraphType, TReturnType>(string name) =>
+        Wrap(base.Field<TGraphType, TReturnType>(name));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field<TGraphType>(string name) =>
+        Wrap(base.Field<TGraphType>(name));
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturnType> Field<TReturnType>(string name, bool nullable = false) =>
+        Wrap(base.Field<TReturnType>(name, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field(string name, Type type) =>
+        Wrap(base.Field(name, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field(string name, IGraphType type) =>
+        Wrap(base.Field(name, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression) =>
+        Wrap(base.Field(name, expression));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression, bool nullable) =>
+        Wrap(base.Field(name, expression, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression, Type type) =>
+        Wrap(base.Field(name, expression, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression) =>
+        Wrap(base.Field(expression));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression, bool nullable) =>
+        Wrap(base.Field(expression, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression, Type type) =>
+        Wrap(base.Field(expression, type));
+
+    EfFieldBuilder<TDbContext, TSource, TReturn> Wrap<TReturn>(FieldBuilder<TSource, TReturn> builder) =>
+        builder as EfFieldBuilder<TDbContext, TSource, TReturn> ?? new(builder.FieldType, GraphQlService);
+
     public ConnectionBuilder<TSource> AddNavigationConnectionField<TReturn>(
         string name,
         Expression<Func<TSource, IEnumerable<TReturn>?>> projection,

--- a/src/GraphQL.EntityFramework/GraphApi/EfObjectGraphType.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfObjectGraphType.cs
@@ -6,6 +6,44 @@ public class EfObjectGraphType<TDbContext, TSource>(IEfGraphQLService<TDbContext
 {
     public IEfGraphQLService<TDbContext> GraphQlService { get; } = graphQlService;
 
+    // The Field methods return an EfFieldBuilder so projection-based resolvers
+    // can be configured without passing the service
+    public override EfFieldBuilder<TDbContext, TSource, TReturnType> Field<TGraphType, TReturnType>(string name) =>
+        Wrap(base.Field<TGraphType, TReturnType>(name));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field<TGraphType>(string name) =>
+        Wrap(base.Field<TGraphType>(name));
+
+    public override EfFieldBuilder<TDbContext, TSource, TReturnType> Field<TReturnType>(string name, bool nullable = false) =>
+        Wrap(base.Field<TReturnType>(name, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field(string name, Type type) =>
+        Wrap(base.Field(name, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, object> Field(string name, IGraphType type) =>
+        Wrap(base.Field(name, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression) =>
+        Wrap(base.Field(name, expression));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression, bool nullable) =>
+        Wrap(base.Field(name, expression, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(string name, Expression<Func<TSource, TProperty>> expression, Type type) =>
+        Wrap(base.Field(name, expression, type));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression) =>
+        Wrap(base.Field(expression));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression, bool nullable) =>
+        Wrap(base.Field(expression, nullable));
+
+    public override EfFieldBuilder<TDbContext, TSource, TProperty> Field<TProperty>(Expression<Func<TSource, TProperty>> expression, Type type) =>
+        Wrap(base.Field(expression, type));
+
+    EfFieldBuilder<TDbContext, TSource, TReturn> Wrap<TReturn>(FieldBuilder<TSource, TReturn> builder) =>
+        builder as EfFieldBuilder<TDbContext, TSource, TReturn> ?? new(builder.FieldType, GraphQlService);
+
     /// <summary>
     /// Map all un-mapped properties. Underlying behaviour is:
     ///

--- a/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class FieldBuilderExtensions
     /// <typeparam name="TReturn">The return type</typeparam>
     /// <typeparam name="TProjection">The projected data type</typeparam>
     /// <param name="builder">The field builder</param>
+    /// <param name="graphQlService">The service used to resolve the DbContext and filters</param>
     /// <param name="projection">Expression to project required data from source</param>
     /// <param name="resolve">Function to resolve field value from projected data</param>
     /// <returns>The field builder for chaining</returns>
@@ -23,6 +24,7 @@ public static class FieldBuilderExtensions
     /// </remarks>
     public static FieldBuilder<TSource, TReturn> Resolve<TDbContext, TSource, TReturn, TProjection>(
         this FieldBuilder<TSource, TReturn> builder,
+        IEfGraphQLService<TDbContext> graphQlService,
         Expression<Func<TSource, TProjection>> projection,
         Func<ResolveProjectionContext<TDbContext, TProjection>, TReturn> resolve)
         where TDbContext : DbContext
@@ -39,26 +41,7 @@ public static class FieldBuilderExtensions
         field.Resolver = new FuncFieldResolver<TSource, TReturn>(
             async context =>
             {
-                // Resolve service from request services
-                var executionContext = context.ExecutionContext;
-                var requestServices = executionContext.RequestServices ?? executionContext.ExecutionOptions.RequestServices;
-               if (requestServices?.GetService(typeof(IEfGraphQLService<TDbContext>)) is not IEfGraphQLService<TDbContext> graphQlService)
-                {
-                    throw new InvalidOperationException($"IEfGraphQLService<{typeof(TDbContext).Name}> not found in request services. Ensure it's registered in the container.");
-                }
-
-                var dbContext = graphQlService.ResolveDbContext(context);
-                var filters = graphQlService.ResolveFilters(context);
-                var projected = compiledProjection(context.Source);
-
-                var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
-                {
-                    Projection = projected,
-                    DbContext = dbContext,
-                    User = context.User,
-                    Filters = filters,
-                    FieldContext = context
-                };
+                var projectionContext = BuildProjectionContext(graphQlService, compiledProjection, context);
 
                 TReturn result;
                 try
@@ -77,7 +60,7 @@ public static class FieldBuilderExtensions
                         exception);
                 }
 
-                return await ApplyFilters(filters, context, dbContext, result);
+                return await ApplyFilters(projectionContext.Filters, context, projectionContext.DbContext, result);
             });
 
         return builder;
@@ -91,6 +74,7 @@ public static class FieldBuilderExtensions
     /// <typeparam name="TReturn">The return type</typeparam>
     /// <typeparam name="TProjection">The projected data type</typeparam>
     /// <param name="builder">The field builder</param>
+    /// <param name="graphQlService">The service used to resolve the DbContext and filters</param>
     /// <param name="projection">Expression to project required data from source</param>
     /// <param name="resolve">Async function to resolve field value from projected data</param>
     /// <returns>The field builder for chaining</returns>
@@ -101,6 +85,7 @@ public static class FieldBuilderExtensions
     /// </remarks>
     public static FieldBuilder<TSource, TReturn> ResolveAsync<TDbContext, TSource, TReturn, TProjection>(
         this FieldBuilder<TSource, TReturn> builder,
+        IEfGraphQLService<TDbContext> graphQlService,
         Expression<Func<TSource, TProjection>> projection,
         Func<ResolveProjectionContext<TDbContext, TProjection>, Task<TReturn>> resolve)
         where TDbContext : DbContext
@@ -117,26 +102,7 @@ public static class FieldBuilderExtensions
         field.Resolver = new FuncFieldResolver<TSource, TReturn>(
             async context =>
             {
-                // Resolve service from request services
-                var executionContext = context.ExecutionContext;
-                var requestServices = executionContext.RequestServices ?? executionContext.ExecutionOptions.RequestServices;
-               if (requestServices?.GetService(typeof(IEfGraphQLService<TDbContext>)) is not IEfGraphQLService<TDbContext> graphQlService)
-                {
-                    throw new InvalidOperationException($"IEfGraphQLService<{typeof(TDbContext).Name}> not found in request services. Ensure it's registered in the container.");
-                }
-
-                var dbContext = graphQlService.ResolveDbContext(context);
-                var filters = graphQlService.ResolveFilters(context);
-                var projected = compiledProjection(context.Source);
-
-                var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
-                {
-                    Projection = projected,
-                    DbContext = dbContext,
-                    User = context.User,
-                    Filters = filters,
-                    FieldContext = context
-                };
+                var projectionContext = BuildProjectionContext(graphQlService, compiledProjection, context);
 
                 TReturn result;
                 try
@@ -155,7 +121,7 @@ public static class FieldBuilderExtensions
                         exception);
                 }
 
-                return await ApplyFilters(filters, context, dbContext, result);
+                return await ApplyFilters(projectionContext.Filters, context, projectionContext.DbContext, result);
             });
 
         return builder;
@@ -169,6 +135,7 @@ public static class FieldBuilderExtensions
     /// <typeparam name="TReturn">The return item type</typeparam>
     /// <typeparam name="TProjection">The projected data type</typeparam>
     /// <param name="builder">The field builder</param>
+    /// <param name="graphQlService">The service used to resolve the DbContext and filters</param>
     /// <param name="projection">Expression to project required data from source</param>
     /// <param name="resolve">Function to resolve list of field values from projected data</param>
     /// <returns>The field builder for chaining</returns>
@@ -179,6 +146,7 @@ public static class FieldBuilderExtensions
     /// </remarks>
     public static FieldBuilder<TSource, IEnumerable<TReturn>> ResolveList<TDbContext, TSource, TReturn, TProjection>(
         this FieldBuilder<TSource, IEnumerable<TReturn>> builder,
+        IEfGraphQLService<TDbContext> graphQlService,
         Expression<Func<TSource, TProjection>> projection,
         Func<ResolveProjectionContext<TDbContext, TProjection>, IEnumerable<TReturn>> resolve)
         where TDbContext : DbContext
@@ -195,26 +163,7 @@ public static class FieldBuilderExtensions
         field.Resolver = new FuncFieldResolver<TSource, IEnumerable<TReturn>>(
             context =>
             {
-                // Resolve service from request services
-                var executionContext = context.ExecutionContext;
-                var requestServices = executionContext.RequestServices ?? executionContext.ExecutionOptions.RequestServices;
-               if (requestServices?.GetService(typeof(IEfGraphQLService<TDbContext>)) is not IEfGraphQLService<TDbContext> graphQlService)
-                {
-                    throw new InvalidOperationException($"IEfGraphQLService<{typeof(TDbContext).Name}> not found in request services. Ensure it's registered in the container.");
-                }
-
-                var dbContext = graphQlService.ResolveDbContext(context);
-                var filters = graphQlService.ResolveFilters(context);
-                var projected = compiledProjection(context.Source);
-
-                var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
-                {
-                    Projection = projected,
-                    DbContext = dbContext,
-                    User = context.User,
-                    Filters = filters,
-                    FieldContext = context
-                };
+                var projectionContext = BuildProjectionContext(graphQlService, compiledProjection, context);
 
                 IEnumerable<TReturn> result;
                 try
@@ -249,6 +198,7 @@ public static class FieldBuilderExtensions
     /// <typeparam name="TReturn">The return item type</typeparam>
     /// <typeparam name="TProjection">The projected data type</typeparam>
     /// <param name="builder">The field builder</param>
+    /// <param name="graphQlService">The service used to resolve the DbContext and filters</param>
     /// <param name="projection">Expression to project required data from source</param>
     /// <param name="resolve">Async function to resolve list of field values from projected data</param>
     /// <returns>The field builder for chaining</returns>
@@ -259,6 +209,7 @@ public static class FieldBuilderExtensions
     /// </remarks>
     public static FieldBuilder<TSource, IEnumerable<TReturn>> ResolveListAsync<TDbContext, TSource, TReturn, TProjection>(
         this FieldBuilder<TSource, IEnumerable<TReturn>> builder,
+        IEfGraphQLService<TDbContext> graphQlService,
         Expression<Func<TSource, TProjection>> projection,
         Func<ResolveProjectionContext<TDbContext, TProjection>, Task<IEnumerable<TReturn>>> resolve)
         where TDbContext : DbContext
@@ -275,26 +226,7 @@ public static class FieldBuilderExtensions
         field.Resolver = new FuncFieldResolver<TSource, IEnumerable<TReturn>>(
             async context =>
             {
-                // Resolve service from request services
-                var executionContext = context.ExecutionContext;
-                var requestServices = executionContext.RequestServices ?? executionContext.ExecutionOptions.RequestServices;
-               if (requestServices?.GetService(typeof(IEfGraphQLService<TDbContext>)) is not IEfGraphQLService<TDbContext> graphQlService)
-                {
-                    throw new InvalidOperationException($"IEfGraphQLService<{typeof(TDbContext).Name}> not found in request services. Ensure it's registered in the container.");
-                }
-
-                var dbContext = graphQlService.ResolveDbContext(context);
-                var filters = graphQlService.ResolveFilters(context);
-                var projected = compiledProjection(context.Source);
-
-                var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
-                {
-                    Projection = projected,
-                    DbContext = dbContext,
-                    User = context.User,
-                    Filters = filters,
-                    FieldContext = context
-                };
+                var projectionContext = BuildProjectionContext(graphQlService, compiledProjection, context);
 
                 IEnumerable<TReturn> result;
                 try
@@ -320,6 +252,20 @@ public static class FieldBuilderExtensions
 
         return builder;
     }
+
+    static ResolveProjectionContext<TDbContext, TProjection> BuildProjectionContext<TDbContext, TSource, TProjection>(
+        IEfGraphQLService<TDbContext> graphQlService,
+        Func<TSource, TProjection> compiledProjection,
+        IResolveFieldContext<TSource> context)
+        where TDbContext : DbContext =>
+        new()
+        {
+            DbContext = graphQlService.ResolveDbContext(context),
+            Filters = graphQlService.ResolveFilters(context),
+            Projection = compiledProjection(context.Source),
+            User = context.User,
+            FieldContext = context
+        };
 
     static async Task<TReturn> ApplyFilters<TDbContext, TReturn>(
         Filters<TDbContext>? filters,
@@ -353,13 +299,17 @@ public static class FieldBuilderExtensions
     /// This ensures the parent query loads the required fields from the database,
     /// even when the field has its own custom resolver.
     /// </summary>
+    /// <typeparam name="TSource">The source entity type</typeparam>
+    /// <typeparam name="TReturn">The return type</typeparam>
+    /// <typeparam name="TProjection">The projected data type</typeparam>
     /// <param name="builder">The field builder</param>
     /// <param name="projection">Expression describing the required entity data</param>
     /// <returns>The field builder for chaining</returns>
-    public static FieldBuilder<TSource, TReturn> WithProjection<TSource, TReturn>(
+    public static FieldBuilder<TSource, TReturn> WithProjection<TSource, TReturn, TProjection>(
         this FieldBuilder<TSource, TReturn> builder,
-        LambdaExpression projection)
+        Expression<Func<TSource, TProjection>> projection)
     {
+        ValidateProjection(projection);
         IncludeAppender.SetProjectionMetadata(builder.FieldType, projection);
         return builder;
     }

--- a/src/Tests/EfFieldBuilderTests.cs
+++ b/src/Tests/EfFieldBuilderTests.cs
@@ -1,0 +1,92 @@
+public class EfFieldBuilderTests
+{
+    class TestEntity
+    {
+        public int Id { get; set; }
+        public TestEntity? Parent { get; set; }
+    }
+
+    class TestDbContext(DbContextOptions options) : DbContext(options);
+
+    class TestGraphType(IEfGraphQLService<TestDbContext> graphQlService) :
+        EfObjectGraphType<TestDbContext, TestEntity>(graphQlService);
+
+    // The service is not touched when defining fields, so none is required
+    static TestGraphType BuildGraphType() => new(null!);
+
+    [Fact]
+    public void Field_returns_EfFieldBuilder_through_fluent_chain()
+    {
+        var graphType = BuildGraphType();
+
+        var builder = graphType.Field<int>("test")
+            .Description("description")
+            .DeprecationReason("reason")
+            .Argument<IntGraphType>("argument")
+            .Configure(_ => _.Metadata["key"] = "value");
+
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, int>>(builder);
+        Assert.Equal("description", builder.FieldType.Description);
+        Assert.Equal("reason", builder.FieldType.DeprecationReason);
+        Assert.Equal("value", builder.FieldType.Metadata["key"]);
+        Assert.NotNull(builder.FieldType.Arguments?.Find("argument"));
+    }
+
+    [Fact]
+    public void Field_overloads_return_EfFieldBuilder()
+    {
+        var graphType = BuildGraphType();
+
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, int>>(graphType.Field<IntGraphType, int>("a"));
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, object>>(graphType.Field<IntGraphType>("b"));
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, object>>(graphType.Field("c", typeof(IntGraphType)));
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, object>>(graphType.Field("d", new IntGraphType()));
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, int>>(graphType.Field("e", _ => _.Id));
+        Assert.IsType<EfFieldBuilder<TestDbContext, TestEntity, int>>(graphType.Field(_ => _.Id));
+    }
+
+    [Fact]
+    public void Resolve_with_projection_after_fluent_chain()
+    {
+        var graphType = BuildGraphType();
+
+        var builder = graphType.Field<int>("test")
+            .Description("description")
+            .Resolve(
+                projection: _ => _.Parent,
+                resolve: _ => _.Projection?.Id ?? 0)
+            .DeprecationReason("reason");
+
+        Assert.True(builder.FieldType.Metadata.ContainsKey("_EF_Projection"));
+        Assert.NotNull(builder.FieldType.Resolver);
+        Assert.Equal("reason", builder.FieldType.DeprecationReason);
+    }
+
+    [Fact]
+    public void Resolve_rejects_identity_projection()
+    {
+        var graphType = BuildGraphType();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            graphType.Field<int>("test")
+                .Resolve(
+                    projection: _ => _,
+                    resolve: _ => _.Projection.Id));
+
+        Assert.Contains("Identity projection", exception.Message);
+    }
+
+    [Fact]
+    public void ResolveAsync_rejects_identity_projection()
+    {
+        var graphType = BuildGraphType();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            graphType.Field<int>("test")
+                .ResolveAsync(
+                    projection: _ => _,
+                    resolve: _ => Task.FromResult(_.Projection.Id)));
+
+        Assert.Contains("Identity projection", exception.Message);
+    }
+}

--- a/src/Tests/FieldBuilderExtensionsTests.cs
+++ b/src/Tests/FieldBuilderExtensionsTests.cs
@@ -8,6 +8,9 @@ public class FieldBuilderExtensionsTests
 
     class TestDbContext(DbContextOptions options) : DbContext(options);
 
+    // Identity projections are rejected before the service is touched, so no real service is required
+    static readonly IEfGraphQLService<TestDbContext> graphQlService = null!;
+
     [Fact]
     public void Resolve_ThrowsArgumentException_WhenIdentityProjectionUsed()
     {
@@ -15,9 +18,10 @@ public class FieldBuilderExtensionsTests
         var field = graphType.Field<int>("test");
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            field.Resolve<TestDbContext, TestEntity, int, TestEntity>(
-            projection: _ => _,
-            resolve: _ => _.Projection.Id));
+            field.Resolve(
+                graphQlService,
+                projection: _ => _,
+                resolve: _ => _.Projection.Id));
 
         Assert.Contains("Identity projection", exception.Message);
         Assert.Contains("_ => _", exception.Message);
@@ -30,9 +34,10 @@ public class FieldBuilderExtensionsTests
         var field = graphType.Field<int>("test");
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            field.Resolve<TestDbContext, TestEntity, int, TestEntity>(
-            projection: _ => _,
-            resolve: _ => _.Projection.Id));
+            field.Resolve(
+                graphQlService,
+                projection: _ => _,
+                resolve: _ => _.Projection.Id));
 
         Assert.Contains("Identity projection", exception.Message);
     }
@@ -44,9 +49,10 @@ public class FieldBuilderExtensionsTests
         var field = graphType.Field<int>("test");
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            field.ResolveAsync<TestDbContext, TestEntity, int, TestEntity>(
-            projection: _ => _,
-            resolve: _ => Task.FromResult(_.Projection.Id)));
+            field.ResolveAsync(
+                graphQlService,
+                projection: _ => _,
+                resolve: _ => Task.FromResult(_.Projection.Id)));
 
         Assert.Contains("Identity projection", exception.Message);
     }
@@ -58,9 +64,10 @@ public class FieldBuilderExtensionsTests
         var field = graphType.Field<IEnumerable<int>>("test");
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            field.ResolveList<TestDbContext, TestEntity, int, TestEntity>(
-            projection: _ => _,
-            resolve: _ => [_.Projection.Id]));
+            field.ResolveList(
+                graphQlService,
+                projection: _ => _,
+                resolve: _ => [_.Projection.Id]));
 
         Assert.Contains("Identity projection", exception.Message);
     }
@@ -72,7 +79,8 @@ public class FieldBuilderExtensionsTests
         var field = graphType.Field<IEnumerable<int>>("test");
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            field.ResolveListAsync<TestDbContext, TestEntity, int, TestEntity>(
+            field.ResolveListAsync(
+                graphQlService,
                 projection: _ => _,
                 resolve: _ => Task.FromResult<IEnumerable<int>>([_.Projection.Id])));
 

--- a/src/Tests/IntegrationTests/Graphs/FieldBuilderProjection/FieldBuilderProjectionGraphType.cs
+++ b/src/Tests/IntegrationTests/Graphs/FieldBuilderProjection/FieldBuilderProjectionGraphType.cs
@@ -47,7 +47,8 @@ public class FieldBuilderProjectionGraphType :
 
         // Enum projection - demonstrates projecting scalar enum types
         Field<NonNullGraphType<StringGraphType>, string>("statusDisplay")
-            .Resolve<IntegrationDbContext, FieldBuilderProjectionEntity, string, EntityStatus>(
+            .Resolve(
+                graphQlService,
                 projection: _ => _.Status,
                 resolve: _ => _.Projection switch
                 {
@@ -59,14 +60,15 @@ public class FieldBuilderProjectionGraphType :
 
         // Navigation property access DOES use projection-based resolve
         Field<NonNullGraphType<StringGraphType>, string>("parentName")
-            .Resolve<IntegrationDbContext, FieldBuilderProjectionEntity, string, FieldBuilderProjectionParentEntity?>(
+            .Resolve(
+                graphQlService,
                 projection: _ => _.Parent,
                 resolve: _ => _.Projection?.Name ?? "No Parent");
 
         // WithProjection sets metadata only (no resolver wrapping) — ensures scalar fields
         // are included in the parent query's SELECT projection even when not explicitly queried
         Field<NonNullGraphType<StringGraphType>, string>("statusViaWithProjection")
-            .WithProjection((Expression<Func<FieldBuilderProjectionEntity, EntityStatus>>)(_ => _.Status))
+            .WithProjection(_ => _.Status)
             .Resolve(_ => _.Source.Status switch
             {
                 EntityStatus.Active => "Active via WithProjection",

--- a/src/Tests/IntegrationTests/Graphs/FieldBuilderProjection/FieldBuilderProjectionGraphType.cs
+++ b/src/Tests/IntegrationTests/Graphs/FieldBuilderProjection/FieldBuilderProjectionGraphType.cs
@@ -48,7 +48,6 @@ public class FieldBuilderProjectionGraphType :
         // Enum projection - demonstrates projecting scalar enum types
         Field<NonNullGraphType<StringGraphType>, string>("statusDisplay")
             .Resolve(
-                graphQlService,
                 projection: _ => _.Status,
                 resolve: _ => _.Projection switch
                 {
@@ -61,7 +60,6 @@ public class FieldBuilderProjectionGraphType :
         // Navigation property access DOES use projection-based resolve
         Field<NonNullGraphType<StringGraphType>, string>("parentName")
             .Resolve(
-                graphQlService,
                 projection: _ => _.Parent,
                 resolve: _ => _.Projection?.Name ?? "No Parent");
 


### PR DESCRIPTION
[Upgrade Guide](https://github.com/SimonCropp/GraphQL.EntityFramework/blob/main/docs/upgradeGuide35.md#projection-based-fieldbuilder-apis)

Removes the explicit type arguments and casts from the projection-based `FieldBuilder` APIs, and makes the analyzer actually see those calls.

## Changes

- `WithProjection` takes `Expression<Func<TSource, TProjection>>`, so the projection lambda no longer needs a cast.
- `Field(...)` on `EfObjectGraphType` and `EfInterfaceGraphType` now returns `EfFieldBuilder<TDbContext, TSource, TReturn>`, which carries the `IEfGraphQLService`. Projection-based `Resolve` and `ResolveAsync` are instance methods on it, with only `TProjection` inferred.
- The fluent `FieldBuilder` methods (`Description`, `Argument`, `Configure`, `Resolve`, etc.) are overridden with covariant return types, so the projection-based methods remain available anywhere in a chain.
- The extension methods `Resolve`, `ResolveAsync`, `ResolveList` and `ResolveListAsync` take the `IEfGraphQLService<TDbContext>` as their first argument. All type arguments are inferred, and the service is used directly at execution time instead of being located through `RequestServices`.
- `FieldBuilderResolveAnalyzer` previously never matched the extension methods (it only inspected the containing type), so GQLEF003 could not fire. It now resolves the receiver type for extension methods, identifies projection-based calls by their `projection` parameter, and has tests for GQLEF003.

## Upgrade guide

### `WithProjection`

Drop the cast:

```cs
// before
.WithProjection((Expression<Func<OrderEntity, OrderStatus>>)(_ => _.Status))

// after
.WithProjection(_ => _.Status)
```

### Projection-based `Resolve` / `ResolveAsync` inside an `EfObjectGraphType` or `EfInterfaceGraphType`

Drop the type arguments. `Field(...)` returns an `EfFieldBuilder` that already knows the service:

```cs
// before
Field<NonNullGraphType<StringGraphType>, string>("parentName")
    .Resolve<MyDbContext, ChildEntity, string, ParentEntity?>(
        projection: _ => _.Parent,
        resolve: _ => _.Projection?.Name);

// after
Field<NonNullGraphType<StringGraphType>, string>("parentName")
    .Resolve(
        projection: _ => _.Parent,
        resolve: _ => _.Projection?.Name);
```

Fluent calls from GraphQL.NET can appear before or after the projection-based resolve. Extension methods from other libraries (for example `Authorize()`) return the base `FieldBuilder`, so place them after it.

### Projection-based resolve on a plain `ObjectGraphType`, or `ResolveList` / `ResolveListAsync`

Pass the `IEfGraphQLService<TDbContext>` as the first argument instead of type arguments:

```cs
// before
.ResolveList<MyDbContext, ParentEntity, ChildEntity, ICollection<ChildEntity>>(
    projection: _ => _.Children,
    resolve: _ => _.Projection);

// after
.ResolveList(
    graphQlService,
    projection: _ => _.Children,
    resolve: _ => _.Projection);
```

The service no longer needs to be resolvable from `RequestServices` for these fields.

### Identity projections

`projection: _ => _` in a projection-based resolve inside an EF graph type is now reported at compile time as GQLEF003 (error), rather than only failing at runtime. Use the regular `Resolve()` for PK/FK access, or project the required navigation.

### Breaking

Source-breaking for callers of the old signatures. The old extension methods and the `LambdaExpression` overload of `WithProjection` are removed rather than kept as overloads.
