### PR TITLE
Use the field name rather than the response key when projecting

### DIFF
--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -223,8 +223,11 @@ class IncludeAppender(
 
         if (context.SubFields is not null)
         {
-            foreach (var (fieldName, fieldInfo) in context.SubFields)
+            foreach (var fieldInfo in context.SubFields.Values)
             {
+                // SubFields is keyed by response key, which is the alias when one is used.
+                // The name of the property to project has to come from the ast node.
+                var fieldName = fieldInfo.Field.Name.StringValue;
                 if (IsConnectionNodeName(fieldName))
                 {
                     ProcessConnectionNodeFields(fieldInfo.Field.SelectionSet, navigationProperties, scalarFields, navProjections, context);

--- a/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          renamed: Value1
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field_on_navigation.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field_on_navigation.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  target: {
+    Data: {
+      childEntities: [
+        {
+          renamedChild: Value2,
+          parentAlias: {
+            renamedParent: Value1
+          }
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   c.Id,
+         c.ParentId,
+         c.Property,
+         case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
+         p.Id,
+         p.Property
+from     ChildEntities as c
+         left outer join
+         ParentEntities as p
+         on c.ParentId = p.Id
+order by c.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -1,4 +1,4 @@
-public partial class IntegrationTests
+﻿public partial class IntegrationTests
 {
     static SqlInstance<IntegrationDbContext> sqlInstance;
 
@@ -1991,6 +1991,59 @@ public partial class IntegrationTests
 
         await using var database = await sqlInstance.Build();
         await RunQuery(database, query, null, null, false, [entity1, entity2, entity3, entity4, entity5]);
+    }
+
+    [Fact]
+    public async Task Aliased_scalar_field()
+    {
+        var query =
+            """
+            {
+              parentEntities (orderBy: {path: "property"})
+              {
+                renamed: property
+              }
+            }
+            """;
+
+        var entity = new ParentEntity
+        {
+            Property = "Value1"
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity]);
+    }
+
+    [Fact]
+    public async Task Aliased_scalar_field_on_navigation()
+    {
+        var query =
+            """
+            {
+              childEntities (orderBy: {path: "property"})
+              {
+                renamedChild: property
+                parentAlias
+                {
+                  renamedParent: property
+                }
+              }
+            }
+            """;
+
+        var entity1 = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var entity2 = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = entity1
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity1, entity2]);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`context.SubFields` is keyed by *response key*, which is the alias whenever a query supplies one. That key was being used as the name of the property to project, so an aliased scalar matched no property on the entity, was silently dropped from the generated `Select`, and came back as `null`.

| query | generated sql | result |
|---|---|---|
| `{ property }` | `select p.Id, p.Property` | `property: Value1` |
| `{ renamed: property }` | `select p.Id` | `renamed: null` |

No error is raised, so this reads as missing data rather than a failure. Aliasing scalars is routine in Relay and Apollo clients.

## Fix

Take the name from the ast node (`fieldInfo.Field.Name.StringValue`) instead of the dictionary key.

Nested fields were never affected, because `EnumerateFields` walks the ast and already used the real field name. Only the first level of sub fields was broken.

This also fixes the connection wrapper drill through as a side effect: `IsConnectionNodeName` was being handed the alias too, so `e: edges { ... }` would previously have failed to drill into the node selection set.

## Tests

- `Aliased_scalar_field` covers the top level case, and asserts the column is now in the generated sql.
- `Aliased_scalar_field_on_navigation` covers an aliased scalar at the top level and through a navigation in one query, locking in the nested behaviour that already worked.
