### PR TITLE
Clamp the start of a `last` page so it cannot go negative

### DIFF
--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -61,19 +61,33 @@ static class ConnectionConverter
     static Connection<T> Last<T>(List<T> list, int last, int? after, int? before, int count)
         where T : class
     {
-        int skip;
-        if (after is null)
-        {
-            // last before
-            skip = before.GetValueOrDefault(count) - last;
-        }
-        else
+        var (skip, take) = LastRange(last, after, before, count);
+
+        return Range(list, skip, take, count, true);
+    }
+
+    /// <summary>
+    /// Resolve the skip/take for a `last` page. When `last` exceeds the number of items available before
+    /// the cursor, the start of the range clamps to zero and the page shrinks to what is available.
+    /// Without the clamp a negative skip reaches the database as a negative SQL OFFSET.
+    /// </summary>
+    static (int skip, int take) LastRange(int last, int? after, int? before, int count)
+    {
+        if (after is not null)
         {
             // last after
-            skip = after.Value + 1;
+            return (after.Value + 1, last);
         }
 
-        return Range(list, skip, take: last, count, true);
+        // last before
+        var start = before.GetValueOrDefault(count);
+        var skip = start - last;
+        if (skip < 0)
+        {
+            return (0, Math.Max(start, 0));
+        }
+
+        return (skip, last);
     }
 
     static Connection<T> Range<T>(
@@ -175,19 +189,9 @@ static class ConnectionConverter
         where TItem : class
         where TDbContext : DbContext
     {
-        int skip;
-        if (after is null)
-        {
-            // last before
-            skip = before.GetValueOrDefault(count) - last;
-        }
-        else
-        {
-            // last after
-            skip = after.Value + 1;
-        }
+        var (skip, take) = LastRange(last, after, before, count);
 
-        return Range(queryable, skip, take: last, count, context, filters, cancel, data);
+        return Range(queryable, skip, take, count, context, filters, cancel, data);
     }
 
     static async Task<Connection<TItem>> Range<TDbContext, TSource, TItem>(

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=20_before=null.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=20_before=null.verified.txt
@@ -1,0 +1,63 @@
+﻿{
+  TotalCount: 10,
+  PageInfo: {
+    HasNextPage: false,
+    HasPreviousPage: false,
+    StartCursor: 0,
+    EndCursor: 9
+  },
+  Edges: [
+    {
+      Cursor: 0,
+      Node: j
+    },
+    {
+      Cursor: 1,
+      Node: i
+    },
+    {
+      Cursor: 2,
+      Node: h
+    },
+    {
+      Cursor: 3,
+      Node: g
+    },
+    {
+      Cursor: 4,
+      Node: f
+    },
+    {
+      Cursor: 5,
+      Node: e
+    },
+    {
+      Cursor: 6,
+      Node: d
+    },
+    {
+      Cursor: 7,
+      Node: c
+    },
+    {
+      Cursor: 8,
+      Node: b
+    },
+    {
+      Cursor: 9,
+      Node: a
+    }
+  ],
+  Items: [
+    j,
+    i,
+    h,
+    g,
+    f,
+    e,
+    d,
+    c,
+    b,
+    a
+  ]
+}

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=5_before=2.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=5_before=2.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  TotalCount: 10,
+  PageInfo: {
+    HasNextPage: true,
+    HasPreviousPage: false,
+    StartCursor: 0,
+    EndCursor: 1
+  },
+  Edges: [
+    {
+      Cursor: 0,
+      Node: b
+    },
+    {
+      Cursor: 1,
+      Node: a
+    }
+  ],
+  Items: [
+    b,
+    a
+  ]
+}

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=20_before=null.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=20_before=null.verified.txt
@@ -1,0 +1,42 @@
+﻿[
+  {
+    Id: Guid_1,
+    Property: a
+  },
+  {
+    Id: Guid_2,
+    Property: b
+  },
+  {
+    Id: Guid_3,
+    Property: c
+  },
+  {
+    Id: Guid_4,
+    Property: d
+  },
+  {
+    Id: Guid_5,
+    Property: e
+  },
+  {
+    Id: Guid_6,
+    Property: f
+  },
+  {
+    Id: Guid_7,
+    Property: g
+  },
+  {
+    Id: Guid_8,
+    Property: h
+  },
+  {
+    Id: Guid_9,
+    Property: i
+  },
+  {
+    Id: Guid_10,
+    Property: j
+  }
+]

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=5_before=2.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=5_before=2.verified.txt
@@ -1,0 +1,10 @@
+﻿[
+  {
+    Id: Guid_1,
+    Property: a
+  },
+  {
+    Id: Guid_2,
+    Property: b
+  }
+]

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
@@ -37,6 +37,10 @@
 
     //last after
     [InlineData(null, 7, 2, null)]
+
+    //last larger than the available range
+    [InlineData(null, null, 20, null)]
+    [InlineData(null, null, 5, 2)]
     public async Task Queryable(int? first, int? after, int? last, int? before)
     {
         var fieldContext = new ResolveFieldContext<string>();
@@ -71,6 +75,9 @@
     //last after
     [InlineData(null, 7, 2, null)]
 
+    //last larger than the available range
+    [InlineData(null, null, 20, null)]
+    [InlineData(null, null, 5, 2)]
     public Task List(int? first, int? after, int? last, int? before)
     {
         var connection = ConnectionConverter.ApplyConnectionContext(list, first, after, last, before);


### PR DESCRIPTION
## Problem

For `last before`, the start of the range was computed as `before - last`. That goes negative as soon as `last` exceeds the number of items available before the cursor.

On the list overload this is harmless, because LINQ to Objects clamps a negative `Skip` to zero. On the queryable overload it reaches the database as a negative `OFFSET`:

```
last: 20 over 3 rows
-> SqlException: The offset specified in an OFFSET clause may not be negative.
```

So any client asking for a page larger than the collection takes down the query. Existing coverage missed it because every `last` case in `ConnectionConverterTests` used `last: 2` against 10 rows.

## Fix

Clamp the start to zero and shrink the page to what is actually available before the cursor, so `last: 20` over 10 rows returns all 10 rather than throwing.

The skip/take arithmetic was duplicated verbatim across the list and queryable overloads, so it moves into a shared `LastRange` and both paths get the clamp.

Flooring take at zero also means a negative `before` cursor now yields an empty page rather than a `FETCH NEXT -1`. That is adjacent rather than the point of this change, but it was free here.

## Tests

Two cases added to both the `Queryable` and `List` theories:

- `last: 20, before: null` — `last` exceeds the total count.
- `last: 5, before: 2` — `last` exceeds the items available before the cursor.

The new snapshots follow the established `last` semantics: existing `last: 2` yields `[j, i]`, so `last: 20` yielding `[j … a]` is consistent.
