### PR TITLE
Interpret rather than emit IL for in memory where predicates

### DIFF
--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
@@ -20,14 +20,14 @@ public static partial class ArgumentProcessor
             if (ArgumentReader.TryReadIds(context, out var idValues))
             {
                 var predicate = ExpressionBuilder<TItem>.BuildIdPredicate("Id", idValues);
-                items = items.Where(predicate.Compile());
+                items = items.Where(Compile(predicate));
             }
         }
 
         if (ArgumentReader.TryReadWhere(context, out var wheres))
         {
             var predicate = ExpressionBuilder<TItem>.BuildPredicate(wheres);
-            items = items.Where(predicate.Compile());
+            items = items.Where(Compile(predicate));
         }
 
         var (orderedItems, order) = Order(items, context);
@@ -49,6 +49,15 @@ public static partial class ArgumentProcessor
 
         return items;
     }
+
+    /// <summary>
+    /// This path runs once per parent node, so a navigation list field is compiled as many times as there
+    /// are parents. Emitting IL costs ~700us a call and leaves behind a DynamicMethod that is never
+    /// collected, which dwarfs the cost of running the predicate over an in memory collection. Interpreting
+    /// is ~20x cheaper to construct and stays ahead until a collection reaches several thousand items.
+    /// </summary>
+    static Func<TItem, bool> Compile<TItem>(Expression<Func<TItem, bool>> predicate) =>
+        predicate.Compile(preferInterpretation: true);
 
     static (IEnumerable<TItem> items, bool order) Order<TItem>(IEnumerable<TItem> queryable, IResolveFieldContext context)
     {

--- a/src/Tests/IntegrationTests/IntegrationTests.Navigation_list_where.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Navigation_list_where.verified.txt
@@ -1,0 +1,29 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          children: [
+            {
+              property: Match
+            }
+          ]
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         c.Id,
+         c.ParentId,
+         c.Property
+from     ParentEntities as p
+         left outer join
+         ChildEntities as c
+         on p.Id = c.ParentId
+order by p.Property,
+         p.Id,
+         c.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -1,4 +1,4 @@
-public partial class IntegrationTests
+﻿public partial class IntegrationTests
 {
     static SqlInstance<IntegrationDbContext> sqlInstance;
 
@@ -1991,6 +1991,41 @@ public partial class IntegrationTests
 
         await using var database = await sqlInstance.Build();
         await RunQuery(database, query, null, null, false, [entity1, entity2, entity3, entity4, entity5]);
+    }
+
+    [Fact]
+    public async Task Navigation_list_where()
+    {
+        var query =
+            """
+            {
+              parentEntities (orderBy: {path: "property"})
+              {
+                children (where: {path: "property", comparison: equal, value: "Match"})
+                {
+                  property
+                }
+              }
+            }
+            """;
+
+        var entity1 = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var entity2 = new ChildEntity
+        {
+            Property = "Match",
+            Parent = entity1
+        };
+        var entity3 = new ChildEntity
+        {
+            Property = "NoMatch",
+            Parent = entity1
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity1, entity2, entity3]);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

The list overload of `ApplyGraphQlArguments` runs once per parent node, so a navigation list field compiles its `where` predicate as many times as there are parents.

`Expression.Compile()` emits IL, which costs roughly 700us per call and leaves behind a `DynamicMethod` that is never collected. Against the ~1.6us it takes to build the expression tree itself, that is a 430x overhead, and it dwarfs the cost of actually running the predicate over an in memory collection.

## Fix

Use `Compile(preferInterpretation: true)` on this path. Measured over 200 parents of 20 children each:

| | |
|---|---|
| IL | 49.3 ms |
| interpreted | 2.1 ms |
| compiled once | 0.34 ms |

Interpretation is ~20x cheaper to construct and stays ahead until a collection reaches several thousand items, which is well beyond what a materialised navigation collection should hold. It also stops leaking a `DynamicMethod` per parent row.

## Why not compile once

Compiling once and reusing would be better again, but there is no safe key to cache on. The predicate depends on the request's variable values, and the only objects stable across parents within a request — the ast node and the `FieldType` — are also reused *across* requests by the document cache, so caching on either would serve one request's predicate to another with different variables.

A content keyed cache would work, but it would be keyed on client input and unbounded, which is the same shape as the existing unbounded `PropertyCache`. Worth doing alongside a fix for that, not before it.

## Tests

`Navigation_list_where` covers a `where` applied to a navigation list field, which is the path this changes. Behaviour is unchanged; the full suite passes.
