### PR TITLE
Apply every filter registered for an entity type

### DIFF
--- a/src/GraphQL.EntityFramework/Filters/Filters.cs
+++ b/src/GraphQL.EntityFramework/Filters/Filters.cs
@@ -1,4 +1,4 @@
-namespace GraphQL.EntityFramework;
+﻿namespace GraphQL.EntityFramework;
 
 #region FiltersSignature
 
@@ -42,7 +42,7 @@ public class Filters<TDbContext>
         Expression<Func<TEntity, TProjection>>? projection,
         AsyncFilter<TProjection> filter)
         where TEntity : class =>
-        entries[typeof(TEntity)] = new FilterEntry<TDbContext, TEntity, TProjection>(
+        AddEntry<TEntity>(new FilterEntry<TDbContext, TEntity, TProjection>(
             async (userContext, data, userPrincipal, item) =>
             {
                 try
@@ -54,13 +54,13 @@ public class Filters<TDbContext>
                     throw new($"Failed to execute filter. {nameof(TEntity)}: {typeof(TEntity)}.", exception);
                 }
             },
-            projection);
+            projection));
 
     internal void Add<TEntity, TProjection>(
         Expression<Func<TEntity, TProjection>>? projection,
         Filter<TProjection> filter)
         where TEntity : class =>
-        entries[typeof(TEntity)] = new FilterEntry<TDbContext, TEntity, TProjection>(
+        AddEntry<TEntity>(new FilterEntry<TDbContext, TEntity, TProjection>(
             (userContext, data, userPrincipal, item) =>
             {
                 try
@@ -72,9 +72,27 @@ public class Filters<TDbContext>
                     throw new($"Failed to execute filter. {nameof(TEntity)}: {typeof(TEntity)}.", exception);
                 }
             },
-            projection);
+            projection));
 
-    Dictionary<Type, IFilterEntry<TDbContext>> entries = [];
+    Dictionary<Type, List<IFilterEntry<TDbContext>>> entries = [];
+
+    /// <summary>
+    /// Filters registered for the same entity type are all applied, and a node is included only if
+    /// every one of them accepts it. This matches how a filter on a base type already composes with
+    /// a filter on a derived type.
+    /// </summary>
+    void AddEntry<TEntity>(IFilterEntry<TDbContext> entry)
+        where TEntity : class
+    {
+        var type = typeof(TEntity);
+        if (!entries.TryGetValue(type, out var forType))
+        {
+            forType = [];
+            entries[type] = forType;
+        }
+
+        forType.Add(entry);
+    }
 
     /// <summary>
     /// Get all filters that apply to the specified entity type (including base type filters).
@@ -85,7 +103,7 @@ public class Filters<TDbContext>
         var type = typeof(TEntity);
         return entries
             .Where(_ => _.Key.IsAssignableFrom(type))
-            .Select(_ => _.Value);
+            .SelectMany(_ => _.Value);
     }
 
     /// <summary>
@@ -94,13 +112,13 @@ public class Filters<TDbContext>
     internal IEnumerable<IFilterEntry<TDbContext>> GetFilters(Type entityType) =>
         entries
             .Where(_ => _.Key.IsAssignableFrom(entityType))
-            .Select(_ => _.Value);
+            .SelectMany(_ => _.Value);
 
     /// <summary>
     /// Get all registered filter entries.
     /// </summary>
     internal IEnumerable<IFilterEntry<TDbContext>> GetAllFilters() =>
-        entries.Values;
+        entries.Values.SelectMany(_ => _);
 
     /// <summary>
     /// Returns true if there are any filters registered.

--- a/src/Tests/IntegrationTests/IntegrationTests.Multiple_filters_for_same_type_all_apply.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Multiple_filters_for_same_type_all_apply.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Visible
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_combined_with_existing_filters.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_combined_with_existing_filters.verified.txt
@@ -4,9 +4,6 @@
       parentEntitiesFiltered: [
         {
           property: Entity1
-        },
-        {
-          property: Entity2
         }
       ]
     }

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -2082,6 +2082,37 @@
     }
 
     [Fact]
+    public async Task Multiple_filters_for_same_type_all_apply()
+    {
+        var filters = new Filters<IntegrationDbContext>();
+        filters.For<ParentEntity>().Add(_ => _.Property != "Hidden");
+        filters.For<ParentEntity>().Add(_ => _.Property != "Secret");
+
+        var query =
+            """
+            {
+              parentEntities (orderBy: {path: "property"})
+              {
+                property
+              }
+            }
+            """;
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(
+            database,
+            query,
+            null,
+            filters,
+            false,
+            [
+                new ParentEntity {Property = "Visible"},
+                new ParentEntity {Property = "Hidden"},
+                new ParentEntity {Property = "Secret"}
+            ]);
+    }
+
+    [Fact]
     public async Task Child_parent_with_alias()
     {
         var query =


### PR DESCRIPTION
## Problem

`Filters` stored one entry per entity type, and `Add` assigned rather than appended:

```csharp
Dictionary<Type, IFilterEntry<TDbContext>> entries = [];

internal void Add<TEntity, TProjection>(...) =>
    entries[typeof(TEntity)] = new FilterEntry<TDbContext, TEntity, TProjection>(...);
```

So registering a second filter for a type silently discarded the first. No error, no warning, and nothing in the response to indicate a rule stopped being enforced.

That matters more than a normal API quirk, because `docs/filters.md` presents filters as the place to put rules that cannot be expressed in the query — "for example when performing authorization". An app that registers a business rule and an authorization rule for the same entity currently runs only whichever was added last.

## Fix

Hold a list per type so `Add` appends.

The rest of the machinery already supported multiple entries and needed no change: `ShouldIncludeItem` already ands across them and short circuits on the first rejection, and `MergeFilterFieldsIntoProjection` already loops over `GetFilters` to collect required fields. Only the storage capped it at one.

This also makes same-type filters compose exactly the way a filter on a base type already composes with one on a derived type, which is the behaviour `GetFilters` was written for.

## Note for review: a changed assertion

`Simplified_filter_combined_with_existing_filters` already existed, and its verified file had the bug baked in. The test registers two filters:

```csharp
// Simplified API filter
filters.For<FilterParentEntity>().Add(
    filter: (_, _, _, e) => e.Id != entity2.Id);

// Traditional API filter with projection
filters.For<FilterParentEntity>().Add(
    projection: _ => _.Property,
    filter: (_, _, _, prop) => prop != "Entity3");
```

One excludes Entity2, the other excludes Entity3, so only Entity1 should survive. The verified file contained `[Entity1, Entity2]` — Entity2 present, because the first filter had been discarded and only the second ran.

The snapshot is updated to `[Entity1]`, which is what the test's name and both of its comments always described. Worth a look, since it changes an assertion that was previously signed off.

## Tests

`Multiple_filters_for_same_type_all_apply` covers the case directly: two filters on one type, one excluding "Hidden" and one excluding "Secret", asserting only "Visible" comes back. On main that test returns "Hidden" as well.
