### PR TITLE
Compile path delegates lazily and bound the path cache

### DIFF
--- a/src/GraphQL.EntityFramework/PropertyAccess/Property.cs
+++ b/src/GraphQL.EntityFramework/PropertyAccess/Property.cs
@@ -2,11 +2,23 @@
     Expression Left,
     Expression<Func<TInput, object>> Lambda,
     ParameterExpression SourceParameter,
-    Func<TInput, object> Func,
     Type PropertyType,
     MemberInfo Info,
     MethodInfo? ListContains)
 {
+    Func<TInput, object>? func;
+
+    /// <summary>
+    /// Compiled on first use rather than up front. Compiling emits IL, which costs orders of
+    /// magnitude more than building the expression tree, and only the in memory paths (list
+    /// ordering, and AutoMap) ever invoke the delegate. The queryable paths use <see cref="Left"/>
+    /// and <see cref="Lambda"/>, so they should not pay for it.
+    /// </summary>
+    public Func<TInput, object> Func =>
+        // A race here just means two threads compile and one result is discarded, which is
+        // harmless: the delegates are equivalent.
+        func ??= Lambda.Compile();
+
     public MethodInfo SafeListContains
     {
         get

--- a/src/GraphQL.EntityFramework/PropertyAccess/PropertyCache.cs
+++ b/src/GraphQL.EntityFramework/PropertyAccess/PropertyCache.cs
@@ -3,35 +3,73 @@
     public static ParameterExpression SourceParameter = Expression.Parameter(typeof(TInput));
     static ConcurrentDictionary<string, Property<TInput>> properties = [];
 
-    public static Property<TInput> GetProperty(string path) =>
-        properties.GetOrAdd(
-            path,
-            _ =>
-            {
-                var left = AggregatePath(_, SourceParameter);
+    // Used by tests to assert the cache stays bounded.
+    internal static int CachedCount => properties.Count;
 
-                var converted = Expression.Convert(left, typeof(object));
-                var lambda = Expression.Lambda<Func<TInput, object>>(converted, SourceParameter);
-                var compile = lambda.Compile();
-                var listContains = ReflectionCache.GetListContains(left.Type);
+    /// <summary>
+    /// Paths arrive from the client, and a self referencing navigation can mint an unlimited number
+    /// of distinct valid paths, so the cache cannot grow with them. On overflow the cache resets
+    /// rather than evicting, which keeps memory bounded without eviction bookkeeping: under normal
+    /// use the cap is never reached, and under a flood of distinct paths genuinely hot paths simply
+    /// repopulate. Rebuilding is cheap now that the delegate is compiled lazily.
+    /// </summary>
+    const int maxCachedPaths = 1000;
 
-                var body = (MemberExpression)left;
-                return new(
-                    Left: left,
-                    Lambda: lambda,
-                    SourceParameter: SourceParameter,
-                    Func: compile,
-                    PropertyType: left.Type,
-                    Info: body.Member,
-                    ListContains: listContains
-                );
-            });
+    /// <summary>
+    /// A deep path expands into a member access per segment, and on the queryable paths into a join
+    /// per segment, so an unbounded depth lets a small request generate an enormous query.
+    /// </summary>
+    const int maxPathDepth = 10;
+
+    public static Property<TInput> GetProperty(string path)
+    {
+        if (properties.TryGetValue(path, out var existing))
+        {
+            return existing;
+        }
+
+        var property = Build(path);
+
+        if (properties.Count >= maxCachedPaths)
+        {
+            properties.Clear();
+        }
+
+        properties.TryAdd(path, property);
+
+        return property;
+    }
+
+    static Property<TInput> Build(string path)
+    {
+        var left = AggregatePath(path, SourceParameter);
+
+        var converted = Expression.Convert(left, typeof(object));
+        var lambda = Expression.Lambda<Func<TInput, object>>(converted, SourceParameter);
+        var listContains = ReflectionCache.GetListContains(left.Type);
+
+        var body = (MemberExpression)left;
+        return new(
+            Left: left,
+            Lambda: lambda,
+            SourceParameter: SourceParameter,
+            PropertyType: left.Type,
+            Info: body.Member,
+            ListContains: listContains
+        );
+    }
 
     static Expression AggregatePath(string path, Expression parameter)
     {
+        var segments = path.Split('.');
+        if (segments.Length > maxPathDepth)
+        {
+            throw new($"Path exceeds the maximum depth of {maxPathDepth}. Type: {typeof(TInput).FullName}, Path: {path}.");
+        }
+
         try
         {
-            return path.Split('.')
+            return segments
                 .Aggregate(parameter, (current, property) =>
                     Expression.MakeMemberAccess(current, GetPropertyOrField(current.Type, property)));
         }

--- a/src/Tests/PropertyCacheTests.cs
+++ b/src/Tests/PropertyCacheTests.cs
@@ -1,4 +1,4 @@
-public class PropertyCacheTests
+﻿public class PropertyCacheTests
 {
     [Fact]
     public void Property()
@@ -62,6 +62,66 @@ public class PropertyCacheTests
 
         Assert.Equal("valueA", a);
         Assert.Equal("valueB", b);
+    }
+
+    [Fact]
+    public void DeepPathIsRejected()
+    {
+        // paths come from the client, and each segment becomes a join on the queryable paths
+        var path = string.Join('.', Enumerable.Repeat("Self", 11)) + ".Public";
+        var exception = Assert.Throws<Exception>(() => PropertyCache<SelfReferencing>.GetProperty(path));
+        Assert.Contains("exceeds the maximum depth", exception.Message);
+    }
+
+    [Fact]
+    public void PathAtMaximumDepthIsAllowed()
+    {
+        var path = string.Join('.', Enumerable.Repeat("Self", 9)) + ".Public";
+        var property = PropertyCache<SelfReferencing>.GetProperty(path);
+        Assert.Equal(typeof(string), property.PropertyType);
+    }
+
+    [Fact]
+    public void CacheDoesNotGrowWithoutBound()
+    {
+        // a self referencing navigation can mint unlimited distinct valid paths
+        for (var i = 1; i <= 3000; i++)
+        {
+            var depth = (i % 9) + 1;
+            var path = string.Join('.', Enumerable.Repeat("Self", depth)) + $".Public";
+            PropertyCache<SelfReferencing>.GetProperty(path);
+
+            // vary the casing to mint distinct keys for the same member
+            PropertyCache<SelfReferencing>.GetProperty(path.Replace("Self", i % 2 == 0 ? "self" : "SELF"));
+        }
+
+        Assert.True(
+            PropertyCache<SelfReferencing>.CachedCount <= 1000,
+            $"cache grew to {PropertyCache<SelfReferencing>.CachedCount}");
+    }
+
+    [Fact]
+    public void FuncStillWorksAfterBeingCompiledLazily()
+    {
+        var target = new SelfReferencing
+        {
+            Self = new()
+            {
+                Public = "Value1"
+            }
+        };
+
+        var property = PropertyCache<SelfReferencing>.GetProperty("Self.Public");
+
+        // invoked twice to cover the memoised path as well as the first compile
+        Assert.Equal("Value1", property.Func(target));
+        Assert.Equal("Value1", property.Func(target));
+    }
+
+    public class SelfReferencing
+    {
+        public SelfReferencing? Self { get; set; }
+        public string? Public { get; set; }
     }
 
     public interface IHasA


### PR DESCRIPTION
Two related problems in `PropertyCache`, both reachable from client supplied `path` values on `where` and `orderBy`. They are together because the fix for the first is what makes the fix for the second cheap.

## Compiling up front

`GetProperty` compiled a delegate as part of building each entry:

```csharp
var lambda = Expression.Lambda<Func<TInput, object>>(converted, SourceParameter);
var compile = lambda.Compile();
```

but `Property.Func` is only ever invoked by the in memory paths — list ordering in `ArgumentProcessor_List.Order`, and `Mapper.Compile` during `AutoMap`. The queryable `where` and `orderBy` paths use `Left` and `Lambda` and never touch the delegate, yet paid full IL emission for every distinct path.

`Func` is now compiled on first access. Measured:

```
uncached GetProperty:  ~700us  ->  1.1us
```

## Unbounded cache

`properties` is a `ConcurrentDictionary` keyed on the client supplied path with no eviction, and each entry previously retained a compiled delegate. A self referencing navigation can mint an unlimited number of distinct valid paths (`Self.Self.Self…`), and `IgnoreCase` means casing variants are distinct keys for the same member.

The cache now resets on overflow at 1000 entries.

Reset rather than evict is deliberate. The obvious alternative — stop caching once full — lets whatever filled the cache squat permanently, so legitimate paths added afterwards never get cached at all. That turns a burst of junk paths into lasting degradation. Resetting bounds memory just as well, needs no eviction bookkeeping, and lets hot paths repopulate. Under normal use the cap is never reached.

This is only cheap because of the change above: rebuilding an entry no longer emits IL.

## Path depth

A depth cap alone would not bound the cache — with depth *D* and *P* properties there are still up to *P^D* distinct valid paths — so it is a separate lever for a separate problem. Each segment becomes a member access, and a join on the queryable paths, so an unbounded depth let a small request generate an enormous query.

Capped at 10, which is far beyond realistic nesting, with an explicit error over it.

## Tests

- `DeepPathIsRejected` / `PathAtMaximumDepthIsAllowed` bracket the depth cap.
- `CacheDoesNotGrowWithoutBound` drives 6000 distinct paths, varying depth and casing, and asserts the cache stays within the cap.
- `FuncStillWorksAfterBeingCompiledLazily` invokes `Func` twice, covering the first compile and the memoised path.
