### PR TITLE
Validate connection cursors instead of letting int.Parse throw

### DIFF
--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -245,16 +245,32 @@ static class ConnectionConverter
 
     static void Parse(string? afterString, string? beforeString, out int? after, out int? before)
     {
-        after = null;
-        if (afterString is not null)
+        after = ParseCursor(afterString, "after");
+        before = ParseCursor(beforeString, "before");
+    }
+
+    /// <summary>
+    /// Cursors are client supplied, so a malformed one is bad input rather than a bug. Parsing with
+    /// int.Parse surfaced a raw FormatException or OverflowException, and a negative value parsed
+    /// happily and then reached the database as a negative SQL OFFSET.
+    /// </summary>
+    static int? ParseCursor(string? value, string name)
+    {
+        if (value is null)
         {
-            after = int.Parse(afterString);
+            return null;
         }
 
-        before = null;
-        if (beforeString is not null)
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cursor))
         {
-            before = int.Parse(beforeString);
+            throw new($"The `{name}` cursor must be an integer. Value: {value}");
         }
+
+        if (cursor < 0)
+        {
+            throw new($"The `{name}` cursor cannot be negative. Value: {value}");
+        }
+
+        return cursor;
     }
 }

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
@@ -85,6 +85,36 @@
             .UseParameters(first, after, last, before);
     }
 
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    [InlineData("1.5")]
+    [InlineData("9999999999999999999")]
+    public void Malformed_cursor_reports_bad_input(string cursor)
+    {
+        // cursors are client supplied, so a malformed one must not surface as a raw FormatException
+        var exception = Assert.Throws<Exception>(
+            () => ConnectionConverter.ApplyConnectionContext(list, 2, cursor, null, null));
+        Assert.Contains("cursor must be an integer", exception.Message);
+    }
+
+    [Fact]
+    public void Negative_after_cursor_is_rejected()
+    {
+        // a negative cursor previously parsed happily and reached the database as a negative OFFSET
+        var exception = Assert.Throws<Exception>(
+            () => ConnectionConverter.ApplyConnectionContext(list, 2, "-5", null, null));
+        Assert.Contains("cursor cannot be negative", exception.Message);
+    }
+
+    [Fact]
+    public void Negative_before_cursor_is_rejected()
+    {
+        var exception = Assert.Throws<Exception>(
+            () => ConnectionConverter.ApplyConnectionContext(list, 2, null, null, "-5"));
+        Assert.Contains("cursor cannot be negative", exception.Message);
+    }
+
     [Fact]
     public void List_after_is_an_exclusive_cursor()
     {


### PR DESCRIPTION
## Problem

Cursors arrive from the client, so a malformed one is bad input rather than a bug. They went straight into `int.Parse`:

```csharp
after = int.Parse(afterString);
before = int.Parse(beforeString);
```

`after: "not-a-number"` surfaced a raw `FormatException`, and a value past `int.MaxValue` an `OverflowException`. Neither says anything useful about which cursor was wrong.

A negative cursor was worse, because it did not throw. It parsed happily and flowed into the skip arithmetic, so `after: "-5"` reached the database as a negative SQL `OFFSET`.

## Fix

`TryParse` against the invariant culture, reject negatives, and name the offending cursor in both messages.

Rejecting a negative rather than clamping it is deliberate. A negative offset has no meaning, so it is a client bug worth reporting rather than silently absorbing. #1379 already clamps the skip arithmetic itself, so this is a second line rather than the only one.

## Tests

- `Malformed_cursor_reports_bad_input` covers garbage, empty, a decimal, and a value that overflows `int`.
- `Negative_after_cursor_is_rejected` and `Negative_before_cursor_is_rejected` cover both cursors.
