### PR TITLE
Preserve string literals and comments when compressing a query

### DIFF
--- a/src/GraphQL.EntityFramework/Compress.cs
+++ b/src/GraphQL.EntityFramework/Compress.cs
@@ -1,11 +1,136 @@
-﻿namespace GraphQL.EntityFramework;
+namespace GraphQL.EntityFramework;
 
 public static class Compress
 {
+    /// <summary>
+    /// Strip insignificant whitespace from a GraphQL query.
+    /// </summary>
+    /// <remarks>
+    /// Scans rather than pattern matches, because whitespace is only insignificant outside string
+    /// literals. A regex that collapses runs of whitespace and strips it around punctuators also
+    /// rewrites the contents of any literal that contains them, so `value: "Smith, John"` silently
+    /// became `value:"Smith,John"`. The query still parses, so the corruption shows up as querying
+    /// for the wrong data rather than as an error.
+    /// </remarks>
     public static string Query(string query)
     {
         Ensure.NotWhiteSpace(nameof(query), query);
-        query = Regex.Replace(query, @"\s+", " ");
-        return Regex.Replace(query, @"\s*(\[|\]|\{|\}|\(|\)|:|\,)\s*", "$1");
+
+        var builder = new StringBuilder(query.Length);
+        var pendingSpace = false;
+        var lastWasPunctuator = false;
+        var index = 0;
+
+        while (index < query.Length)
+        {
+            var current = query[index];
+
+            if (char.IsWhiteSpace(current))
+            {
+                pendingSpace = true;
+                index++;
+                continue;
+            }
+
+            // A comment runs to the end of the line and carries no meaning. It has to be dropped
+            // rather than collapsed, since turning the newline into a space would pull the rest of
+            // the query into the comment.
+            if (current == '#')
+            {
+                while (index < query.Length &&
+                       query[index] is not ('\n' or '\r'))
+                {
+                    index++;
+                }
+
+                pendingSpace = true;
+                continue;
+            }
+
+            var isPunctuator = IsPunctuator(current);
+
+            // Whitespace is only needed to keep two names apart
+            if (pendingSpace &&
+                builder.Length > 0 &&
+                !lastWasPunctuator &&
+                !isPunctuator)
+            {
+                builder.Append(' ');
+            }
+
+            pendingSpace = false;
+
+            if (current == '"')
+            {
+                index = AppendStringValue(query, index, builder);
+                lastWasPunctuator = false;
+                continue;
+            }
+
+            builder.Append(current);
+            lastWasPunctuator = isPunctuator;
+            index++;
+        }
+
+        return builder.ToString();
     }
+
+    static bool IsPunctuator(char character) =>
+        character is '[' or ']' or '{' or '}' or '(' or ')' or ':' or ',';
+
+    /// <summary>
+    /// Copy a string literal through untouched, and return the index just past it.
+    /// </summary>
+    static int AppendStringValue(string query, int index, StringBuilder builder)
+    {
+        if (IsBlockStringDelimiter(query, index))
+        {
+            var end = query.IndexOf("\"\"\"", index + 3, StringComparison.Ordinal);
+            if (end == -1)
+            {
+                // Unterminated. Nothing sensible to compress, so pass the remainder through and let
+                // the server report the syntax error.
+                builder.Append(query, index, query.Length - index);
+                return query.Length;
+            }
+
+            var length = end + 3 - index;
+            builder.Append(query, index, length);
+            return index + length;
+        }
+
+        builder.Append('"');
+        index++;
+
+        while (index < query.Length)
+        {
+            var current = query[index];
+            builder.Append(current);
+            index++;
+
+            if (current == '\\')
+            {
+                // The escaped character is part of the literal, so a `\"` does not end it
+                if (index < query.Length)
+                {
+                    builder.Append(query[index]);
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (current == '"')
+            {
+                break;
+            }
+        }
+
+        return index;
+    }
+
+    static bool IsBlockStringDelimiter(string query, int index) =>
+        index + 2 < query.Length &&
+        query[index + 1] == '"' &&
+        query[index + 2] == '"';
 }

--- a/src/GraphQL.EntityFramework/Testing/ClientQueryExecutor.cs
+++ b/src/GraphQL.EntityFramework/Testing/ClientQueryExecutor.cs
@@ -26,7 +26,9 @@ public class ClientQueryExecutor(Func<object, string> json, string uri = "graphq
         Ensure.NotWhiteSpace(nameof(query), query);
         var compressed = CompressQuery(query);
         var variablesString = ToJson(variables);
-        var getUri = $"{uri}?query={compressed}&variables={variablesString}";
+        // Escaped, since a query containing an `&` or a `#` would otherwise split into another
+        // query string parameter or be truncated as a fragment
+        var getUri = $"{uri}?query={Uri.EscapeDataString(compressed)}&variables={Uri.EscapeDataString(variablesString)}";
         var request = new HttpRequestMessage(HttpMethod.Get, getUri);
         headerAction?.Invoke(request.Headers);
         return client.SendAsync(request);

--- a/src/Tests/CompressTests.cs
+++ b/src/Tests/CompressTests.cs
@@ -16,4 +16,52 @@
         return Verify(Compress.Query(query))
             .Snapshot("query($id:String!){companies(ids:[$id]){id}}");
     }
+
+    [Fact]
+    public Task StringLiteralIsPreserved()
+    {
+        // whitespace inside a literal is significant, and stripping it silently queried for
+        // different data rather than raising an error
+        var query = """{users(where: {path: "name", comparison: equal, value: "Smith, John: Jr"}){id}}""";
+        return Verify(Compress.Query(query))
+            .Snapshot("""{users(where:{path:"name",comparison:equal,value:"Smith, John: Jr"}){id}}""");
+    }
+
+    [Fact]
+    public Task EscapedQuoteDoesNotEndTheLiteral()
+    {
+        var query = """{users(where: {value: "a \" b,  c"}){id}}""";
+        return Verify(Compress.Query(query))
+            .Snapshot("""{users(where:{value:"a \" b,  c"}){id}}""");
+    }
+
+    [Fact]
+    public Task BlockStringIsPreserved()
+    {
+        var query = "{users(where: {value: \"\"\"a,  b: c\"\"\"}){id}}";
+        return Verify(Compress.Query(query))
+            .Snapshot("{users(where:{value:\"\"\"a,  b: c\"\"\"}){id}}");
+    }
+
+    [Fact]
+    public Task CommentIsRemovedWithoutSwallowingTheQuery()
+    {
+        // collapsing the newline into a space would pull the rest of the query into the comment
+        var query = """
+                    {
+                      # a comment
+                      users
+                      {
+                        id
+                      }
+                    }
+                    """;
+        return Verify(Compress.Query(query))
+            .Snapshot("{users{id}}");
+    }
+
+    [Fact]
+    public Task NamesStaySeparated() =>
+        Verify(Compress.Query("query Named { users { id name } }"))
+            .Snapshot("query Named{users{id name}}");
 }


### PR DESCRIPTION
## Problem

`Compress.Query` minified with two regexes:

```csharp
query = Regex.Replace(query, @"\s+", " ");
return Regex.Replace(query, @"\s*(\[|\]|\{|\}|\(|\)|:|\,)\s*", "$1");
```

Whitespace in GraphQL is only insignificant *outside* string literals, and a regex cannot tell the difference. Any literal containing a space next to a punctuator was rewritten:

```
value: "Smith, John: Jr"   ->   value:"Smith,John:Jr"
```

The query still parses, so this surfaces as querying for the wrong data rather than as an error.

Comments broke the same function from the other direction. Collapsing `\s+` turns the newline ending a `#` comment into a space, pulling the remainder of the query into the comment.

## Fix

Replace the regexes with a scan that copies literals through untouched — handling escaped quotes and `"""` block strings — and drops comments rather than collapsing them.

Output for input containing no literals and no comments is byte identical, so the pre-existing `Simple` snapshot holds unchanged. That is the main evidence the rewrite did not shift behaviour.

## Also

`ClientQueryExecutor.ExecuteGet` interpolated the query and variables into a url raw:

```csharp
var getUri = $"{uri}?query={compressed}&variables={variablesString}";
```

A query containing an `&` split into another query string parameter, and a `#` truncated it as a fragment. Both are now escaped with `Uri.EscapeDataString`.

## Tests

- `StringLiteralIsPreserved` — the `"Smith, John: Jr"` case.
- `EscapedQuoteDoesNotEndTheLiteral` — a `\"` inside a literal.
- `BlockStringIsPreserved` — `"""…"""`.
- `CommentIsRemovedWithoutSwallowingTheQuery` — a `#` comment mid query.
- `NamesStaySeparated` — the space between two names is load bearing and must survive.
