### PR TITLE
Order projection bindings by member name

### DIFF
--- a/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
@@ -1,4 +1,4 @@
-namespace GraphQL.EntityFramework;
+﻿namespace GraphQL.EntityFramework;
 
 static class SelectExpressionBuilder
 {
@@ -139,6 +139,8 @@ static class SelectExpressionBuilder
                 bindings.Add(binding);
             }
         }
+
+        Sort(bindings);
 
         var memberInit = Expression.MemberInit(entityMetadata.NewInstance, bindings);
         return Expression.Lambda<Func<TEntity, TEntity>>(memberInit, parameter);
@@ -350,8 +352,19 @@ static class SelectExpressionBuilder
             }
         }
 
+        Sort(bindings);
+
         return true;
     }
+
+    /// <summary>
+    /// Bindings are collected in the order the fields were requested, so the same set of fields
+    /// asked for in a different order produced a structurally different expression tree, and
+    /// therefore a separate entry in EF's compiled query cache for identical work. Ordering by
+    /// member name makes the tree depend only on which fields were requested.
+    /// </summary>
+    static void Sort(List<MemberBinding> bindings) =>
+        bindings.Sort((x, y) => string.CompareOrdinal(x.Member.Name, y.Member.Name));
 
     static bool TryBuildNestedNavigationBinding(
         Expression sourceExpression,

--- a/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_denies_when_no_match.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_denies_when_no_match.verified.txt
@@ -6,11 +6,11 @@
   },
   sql: {
     Text:
-select top (2) f.Id,
+select top (2) cast (0 as bit),
+               f0.CommonProperty,
                f.BaseEntityId,
-               f.Property,
-               cast (0 as bit),
-               f0.CommonProperty
+               f.Id,
+               f.Property
 from   FilterReferenceEntities as f
        inner join
        FilterBaseEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_uses_include.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_uses_include.verified.txt
@@ -9,11 +9,11 @@
   },
   sql: {
     Text:
-select top (2) f.Id,
+select top (2) cast (0 as bit),
+               f0.CommonProperty,
                f.BaseEntityId,
-               f.Property,
-               cast (0 as bit),
-               f0.CommonProperty
+               f.Id,
+               f.Property
 from   FilterReferenceEntities as f
        inner join
        FilterBaseEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field_on_navigation.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Aliased_scalar_field_on_navigation.verified.txt
@@ -14,11 +14,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.AutoMap_ListNavigation_AppliesFilters.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.AutoMap_ListNavigation_AppliesFilters.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_included_in_query_field_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_included_in_query_field_projection.verified.txt
@@ -15,8 +15,8 @@
   },
   sql: {
     Text:
-select   d.Id,
-         d.EntityType,
+select   d.EntityType,
+         d.Id,
          d.Property
 from     DiscriminatorBaseEntities as d
 where    d.EntityType = 0

--- a/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_included_in_single_field_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_included_in_single_field_projection.verified.txt
@@ -8,8 +8,8 @@
   },
   sql: {
     Text:
-select top (2) d.Id,
-               d.EntityType,
+select top (2) d.EntityType,
+               d.Id,
                d.Property
 from   DiscriminatorBaseEntities as d
 where  d.EntityType = 0

--- a/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_returns_correct_value_when_queried.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.CLR_discriminator_returns_correct_value_when_queried.verified.txt
@@ -9,8 +9,8 @@
   },
   sql: {
     Text:
-select top (2) d.Id,
-               d.EntityType,
+select top (2) d.EntityType,
+               d.Id,
                d.Property
 from   DiscriminatorBaseEntities as d
 where  d.EntityType = 1

--- a/src/Tests/IntegrationTests/IntegrationTests.Child_filtered.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Child_filtered.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Child_parent.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Child_parent.verified.txt
@@ -26,11 +26,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Child_parent_with_alias.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Child_parent_with_alias.verified.txt
@@ -23,10 +23,10 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Collection_navigation_to_entity_with_readonly_property_falls_back_to_full_include.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Collection_navigation_to_entity_with_readonly_property_falls_back_to_full_include.verified.txt
@@ -17,13 +17,13 @@
   sql: {
     Text:
 select   r.Id,
-         r.Property,
          r0.Id,
          r0.Age,
          r0.ComputedInDb,
          r0.FirstName,
          r0.LastName,
-         r0.ReadOnlyParentId
+         r0.ReadOnlyParentId,
+         r.Property
 from     ReadOnlyParentEntities as r
          left outer join
          ReadOnlyEntities as r0

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_items_with_fragment_spread_and_children.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_items_with_fragment_spread_and_children.verified.txt
@@ -25,10 +25,10 @@ from   ParentEntities as p
     {
       Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   p.Id,
                    p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_parent_child_Filtered.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_parent_child_Filtered.verified.txt
@@ -38,9 +38,9 @@ from   FilterParentEntities as f
     {
       Text:
 select   f1.Id,
-         f1.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f1.Property
 from     (select   f.Id,
                    f.Property
           from     FilterParentEntities as f

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_bool_value_type_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_bool_value_type_projection.verified.txt
@@ -17,9 +17,9 @@
   },
   sql: {
     Text:
-select   f.Id,
-         f.Name,
-         f.Age
+select   f.Age,
+         f.Id,
+         f.Name
 from     FieldBuilderProjectionEntities as f
 order by f.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_datetime_value_type_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_datetime_value_type_projection.verified.txt
@@ -12,9 +12,9 @@
   },
   sql: {
     Text:
-select   f.Id,
-         f.Name,
-         f.CreatedAt
+select   f.CreatedAt,
+         f.Id,
+         f.Name
 from     FieldBuilderProjectionEntities as f
 order by f.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_enum_projection_through_navigation.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_enum_projection_through_navigation.verified.txt
@@ -14,8 +14,8 @@
   sql: {
     Text:
 select   f.Id,
-         f.Name,
-         f0.Id
+         f0.Id,
+         f.Name
 from     FieldBuilderProjectionParentEntities as f
          left outer join
          FieldBuilderProjectionEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_int_value_type_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_int_value_type_projection.verified.txt
@@ -12,9 +12,9 @@
   },
   sql: {
     Text:
-select   f.Id,
-         f.Name,
-         f.Age
+select   f.Age,
+         f.Id,
+         f.Name
 from     FieldBuilderProjectionEntities as f
 order by f.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_multiple_value_types_combined.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_multiple_value_types_combined.verified.txt
@@ -20,9 +20,9 @@
   },
   sql: {
     Text:
-select   f.Id,
+select   f.Age,
+         f.Id,
          f.Name,
-         f.Age,
          f.Salary,
          f.Score,
          f.ViewCount

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_bool_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_bool_projection.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
+         f0.IsActive,
          f0.Property,
-         f0.IsActive
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_datetime_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_datetime_projection.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
+         f0.CreatedAt,
          f0.Id,
          f0.Property,
-         f0.CreatedAt
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_guid_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_guid_projection.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_int_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_int_projection.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
+         f0.Age,
          f0.Id,
          f0.Property,
-         f0.Age
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_navigation_properties_merged_with_graphql_fields.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_navigation_properties_merged_with_graphql_fields.verified.txt
@@ -20,11 +20,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_bool_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_bool_projection.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
+         f0.NullableIsActive,
          f0.Property,
-         f0.NullableIsActive
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_datetime_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_datetime_projection.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
+         f0.NullableCreatedAt,
          f0.Property,
-         f0.NullableCreatedAt
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_int_projection_is_null.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_int_projection_is_null.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
+         f0.NullableAge,
          f0.Property,
-         f0.NullableAge
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_int_projection_with_value.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_int_projection_with_value.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
+         f0.NullableAge,
          f0.Property,
-         f0.NullableAge
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_string_is_not_null.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_nullable_string_is_not_null.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_TPH_inheritance_should_not_select_all_fields.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_TPH_inheritance_should_not_select_all_fields.verified.txt
@@ -8,11 +8,11 @@
   },
   sql: {
     Text:
-select top (2) f.Id,
-               f.BaseEntityId,
-               cast (0 as bit),
+select top (2) cast (0 as bit),
                f0.CommonProperty,
-               f0.Id
+               f0.Id,
+               f.BaseEntityId,
+               f.Id
 from   FilterReferenceEntities as f
        inner join
        FilterBaseEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_abstract_navigation_should_not_throw.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_abstract_navigation_should_not_throw.verified.txt
@@ -14,13 +14,13 @@
   sql: {
     Text:
 select   d.Id,
-         d.ParentId,
-         d.TypedParentId,
-         d.Property,
          b.Id,
          b.Discriminator,
          b.Property,
-         b.Status
+         b.Status,
+         d.ParentId,
+         d.Property,
+         d.TypedParentId
 from     DerivedChildEntities as d
          left outer join
          BaseEntities as b

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_string_projection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_string_projection.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_projection_with_For.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_projection_with_For.verified.txt
@@ -17,10 +17,10 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
+select   s.BoolValue,
+         s.Id,
          s.IntValue,
-         s.BoolValue
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_async_filter.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_async_filter.verified.txt
@@ -12,10 +12,10 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
+select   s.GuidValue,
+         s.Id,
          s.IntValue,
-         s.GuidValue
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_nested_navigation_property.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_nested_navigation_property.verified.txt
@@ -22,22 +22,22 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
-         s.Id,
-         s.Property,
          s.Age,
+         s.Id,
          s.IsActive,
          s.c,
+         s.Property,
          s.Property0,
-         s.Id0
+         s.Id0,
+         f.Property
 from     FilterParentEntities as f
          left outer join
-         (select f0.Id,
-                 f0.Property,
-                 f0.Age,
+         (select f0.Age,
+                 f0.Id,
                  f0.IsActive,
                  case when f1.Id is null then cast (1 as bit) else cast (0 as bit) end as c,
-                 f1.Property as Property0,
+                 f1.Property,
+                 f0.Property as Property0,
                  f1.Id as Id0,
                  f0.ParentId
           from   FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_three_properties.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_anonymous_type_with_three_properties.verified.txt
@@ -12,11 +12,11 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
+select   s.BoolValue,
+         s.DateTimeValue,
+         s.Id,
          s.IntValue,
-         s.BoolValue,
-         s.DateTimeValue
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_async_int_overload.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_async_int_overload.verified.txt
@@ -12,8 +12,8 @@
   sql: {
     Text:
 select   s.Id,
-         s.Name,
-         s.IntValue
+         s.IntValue,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_bool_overload.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_bool_overload.verified.txt
@@ -11,9 +11,9 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
-         s.BoolValue
+select   s.BoolValue,
+         s.Id,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_boolean_expression_shorthand.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_boolean_expression_shorthand.verified.txt
@@ -15,9 +15,9 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
-         s.BoolValue
+select   s.BoolValue,
+         s.Id,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_datetime_overload.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_datetime_overload.verified.txt
@@ -11,9 +11,9 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
-         s.DateTimeValue
+select   s.DateTimeValue,
+         s.Id,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_guid_overload.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_guid_overload.verified.txt
@@ -11,9 +11,9 @@
   },
   sql: {
     Text:
-select   s.Id,
-         s.Name,
-         s.GuidValue
+select   s.GuidValue,
+         s.Id,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_using_int_overload.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_using_int_overload.verified.txt
@@ -12,8 +12,8 @@
   sql: {
     Text:
 select   s.Id,
-         s.Name,
-         s.IntValue
+         s.IntValue,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
@@ -32,10 +32,10 @@ from   ParentEntities as p
     {
       Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   p.Id,
                    p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_without_projection_async.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_without_projection_async.verified.txt
@@ -20,8 +20,8 @@
   sql: {
     Text:
 select   s.Id,
-         s.Name,
-         s.IntValue
+         s.IntValue,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_without_projection_sync.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_without_projection_sync.verified.txt
@@ -20,8 +20,8 @@
   sql: {
     Text:
 select   s.Id,
-         s.Name,
-         s.IntValue
+         s.IntValue,
+         s.Name
 from     SimpleTypeFilterEntities as s
 order by s.Name
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.FirstParent_Child.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FirstParent_Child.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   top (1) p.Id,
                            p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.FirstParent_Child_WithFragment.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FirstParent_Child_WithFragment.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   top (1) p.Id,
                            p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.First_IdOnly.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.First_IdOnly.verified.txt
@@ -14,10 +14,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   top (1) p.Id,
                            p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.First_NoArgs.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.First_NoArgs.verified.txt
@@ -14,10 +14,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select   top (1) p.Id,
                            p.Property
           from     ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.ForeignKey_CustomField_UsesProjectedForeignKey.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ForeignKey_CustomField_UsesProjectedForeignKey.verified.txt
@@ -41,11 +41,11 @@
     {
       Text:
 select   d.Id,
-         d.Name,
-         d.IsActive,
-         e.Id,
          e.DepartmentId,
-         e.Name
+         e.Id,
+         e.Name,
+         d.IsActive,
+         d.Name
 from     Departments as d
          left outer join
          Employees as e

--- a/src/Tests/IntegrationTests/IntegrationTests.ForeignKey_NestedNavigation_IncludesForeignKeyInProjection.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ForeignKey_NestedNavigation_IncludesForeignKeyInProjection.verified.txt
@@ -19,10 +19,10 @@
     {
       Text:
 select   d.Id,
-         d.Name,
-         e.Id,
          e.DepartmentId,
-         e.Name
+         e.Id,
+         e.Name,
+         d.Name
 from     Departments as d
          left outer join
          Employees as e

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude.verified.txt
@@ -19,11 +19,11 @@
   sql: {
     Text:
 select   m.Id,
-         m.RightName,
          s.Id,
          s.LeftName,
          s.ManyToManyLeftEntityId,
-         s.ManyToManyRightEntityId
+         s.ManyToManyRightEntityId,
+         m.RightName
 from     ManyToManyRightEntities as m
          left outer join
          (select m3.Id,

--- a/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude_notEqual.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ManyToManyLeftWhereAndInclude_notEqual.verified.txt
@@ -27,11 +27,11 @@
   sql: {
     Text:
 select   m.Id,
-         m.RightName,
          s.Id,
          s.LeftName,
          s.ManyToManyLeftEntityId,
-         s.ManyToManyRightEntityId
+         s.ManyToManyRightEntityId,
+         m.RightName
 from     ManyToManyRightEntities as m
          left outer join
          (select m3.Id,

--- a/src/Tests/IntegrationTests/IntegrationTests.Many_children.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Many_children.verified.txt
@@ -12,13 +12,13 @@
   },
   sql: {
     Text:
-select w.Id,
-       case when c.Id is null then cast (1 as bit) else cast (0 as bit) end,
+select case when c.Id is null then cast (1 as bit) else cast (0 as bit) end,
        c.Id,
        c.ParentId,
        case when c0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        c0.Id,
-       c0.ParentId
+       c0.ParentId,
+       w.Id
 from   WithManyChildrenEntities as w
        left outer join
        Child1Entities as c

--- a/src/Tests/IntegrationTests/IntegrationTests.Multiple_nested.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Multiple_nested.verified.txt
@@ -17,10 +17,10 @@
 select l.Id,
        case when l0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l0.Id,
-       l0.Level3EntityId,
        case when l1.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l1.Id,
-       l1.Property
+       l1.Property,
+       l0.Level3EntityId
 from   Level1Entities as l
        left outer join
        Level2Entities as l0

--- a/src/Tests/IntegrationTests/IntegrationTests.Multiple_nested_Filtered.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Multiple_nested_Filtered.verified.txt
@@ -15,10 +15,10 @@
 select l.Id,
        case when l0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l0.Id,
-       l0.Level3EntityId,
        case when l1.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l1.Id,
-       l1.Property
+       l1.Property,
+       l0.Level3EntityId
 from   Level1Entities as l
        left outer join
        Level2Entities as l0

--- a/src/Tests/IntegrationTests/IntegrationTests.Named_record_filter_projection_should_select_minimal_columns.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Named_record_filter_projection_should_select_minimal_columns.verified.txt
@@ -14,11 +14,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Navigation_to_abstract_type_falls_back_to_full_include.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Navigation_to_abstract_type_falls_back_to_full_include.verified.txt
@@ -14,13 +14,13 @@
   sql: {
     Text:
 select   d.Id,
-         d.ParentId,
-         d.TypedParentId,
-         d.Property,
          b.Id,
          b.Discriminator,
          b.Property,
-         b.Status
+         b.Status,
+         d.ParentId,
+         d.Property,
+         d.TypedParentId
 from     DerivedChildEntities as d
          left outer join
          BaseEntities as b

--- a/src/Tests/IntegrationTests/IntegrationTests.Null_on_nested.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Null_on_nested.verified.txt
@@ -17,10 +17,10 @@
 select l.Id,
        case when l0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l0.Id,
-       l0.Level3EntityId,
        case when l1.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l1.Id,
-       l1.Property
+       l1.Property,
+       l0.Level3EntityId
 from   Level1Entities as l
        left outer join
        Level2Entities as l0

--- a/src/Tests/IntegrationTests/IntegrationTests.Null_on_nested_notEqual.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Null_on_nested_notEqual.verified.txt
@@ -15,10 +15,10 @@
 select l.Id,
        case when l0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l0.Id,
-       l0.Level3EntityId,
        case when l1.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l1.Id,
-       l1.Property
+       l1.Property,
+       l0.Level3EntityId
 from   Level1Entities as l
        left outer join
        Level2Entities as l0

--- a/src/Tests/IntegrationTests/IntegrationTests.Owned.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Owned.verified.txt
@@ -11,10 +11,10 @@
   },
   sql: {
     Text:
-select top (2) o.Id,
-               o.Property,
-               cast (0 as bit),
-               o.Child1_Property
+select top (2) cast (0 as bit),
+               o.Child1_Property,
+               o.Id,
+               o.Property
 from   OwnedParents as o
 where  o.Id = @p1,
     Parameters: {

--- a/src/Tests/IntegrationTests/IntegrationTests.Parent_child_with_id.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Parent_child_with_id.verified.txt
@@ -16,10 +16,10 @@
   sql: {
     Text:
 select   p.Id,
-         p.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p.Property
 from     ParentEntities as p
          left outer join
          ChildEntities as c

--- a/src/Tests/IntegrationTests/IntegrationTests.Parent_with_id_child_with_id.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Parent_with_id_child_with_id.verified.txt
@@ -16,10 +16,10 @@
   sql: {
     Text:
 select   p.Id,
-         p.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p.Property
 from     ParentEntities as p
          left outer join
          ChildEntities as c

--- a/src/Tests/IntegrationTests/IntegrationTests.ProjectionBased_NavigationList_AppliesFilters.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ProjectionBased_NavigationList_AppliesFilters.verified.txt
@@ -16,9 +16,9 @@
   sql: {
     Text:
 select   f.Id,
-         f.Property,
          f0.Id,
-         f0.Property
+         f0.Property,
+         f.Property
 from     FilterParentEntities as f
          left outer join
          FilterChildEntities as f0

--- a/src/Tests/IntegrationTests/IntegrationTests.ProjectionBased_NavigationSingle_AppliesFilters.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.ProjectionBased_NavigationSingle_AppliesFilters.verified.txt
@@ -15,10 +15,10 @@
 select l.Id,
        case when l0.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l0.Id,
-       l0.Level3EntityId,
        case when l1.Id is null then cast (1 as bit) else cast (0 as bit) end,
        l1.Id,
-       l1.Property
+       l1.Property,
+       l0.Level3EntityId
 from   Level1Entities as l
        left outer join
        Level2Entities as l0

--- a/src/Tests/IntegrationTests/IntegrationTests.Query_Cyclic.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Query_Cyclic.verified.txt
@@ -62,28 +62,28 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property,
          s.Id,
-         s.ParentId,
-         s.Property,
          s.c,
          s.Id0,
-         s.Property0
+         s.Property,
+         s.ParentId,
+         s.Property0,
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p
          on c.ParentId = p.Id
          left outer join
          (select c0.Id,
-                 c0.ParentId,
-                 c0.Property,
                  case when p0.Id is null then cast (1 as bit) else cast (0 as bit) end as c,
                  p0.Id as Id0,
-                 p0.Property as Property0
+                 p0.Property,
+                 c0.ParentId,
+                 c0.Property as Property0
           from   ChildEntities as c0
                  left outer join
                  ParentEntities as p0

--- a/src/Tests/IntegrationTests/IntegrationTests.Query_NoTracking.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Query_NoTracking.verified.txt
@@ -26,11 +26,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Query_entity_with_readonly_properties.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Query_entity_with_readonly_properties.verified.txt
@@ -17,11 +17,11 @@
   },
   sql: {
     Text:
-select   r.Id,
-         r.ReadOnlyParentId,
+select   r.Age,
          r.FirstName,
+         r.Id,
          r.LastName,
-         r.Age
+         r.ReadOnlyParentId
 from     ReadOnlyEntities as r
 order by r.Id
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Query_without_select_projection_with_navigation_filter.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Query_without_select_projection_with_navigation_filter.verified.txt
@@ -12,10 +12,10 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_WithFragment.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_WithFragment.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_mutation.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SingleParent_Child_mutation.verified.txt
@@ -17,10 +17,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_IdOnly.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_IdOnly.verified.txt
@@ -14,10 +14,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_NoArgs.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_NoArgs.verified.txt
@@ -14,10 +14,10 @@
   sql: {
     Text:
 select   p0.Id,
-         p0.Property,
          c.Id,
          c.ParentId,
-         c.Property
+         c.Property,
+         p0.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_child_to_parent_walkback_skipped.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_child_to_parent_walkback_skipped.verified.txt
@@ -17,24 +17,24 @@
   sql: {
     Text:
 select   p1.Id,
-         p1.Property,
          s.Id,
-         s.ParentId,
-         s.Property,
          s.c,
          s.Id0,
-         s.Property0
+         s.Property,
+         s.ParentId,
+         s.Property0,
+         p1.Property
 from     (select top (2) p.Id,
                          p.Property
           from   ParentEntities as p
           where  p.Id = @p1) as p1
          left outer join
          (select c.Id,
-                 c.ParentId,
-                 c.Property,
                  case when p0.Id is null then cast (1 as bit) else cast (0 as bit) end as c,
                  p0.Id as Id0,
-                 p0.Property as Property0
+                 p0.Property,
+                 c.ParentId,
+                 c.Property as Property0
           from   ChildEntities as c
                  left outer join
                  ParentEntities as p0

--- a/src/Tests/IntegrationTests/IntegrationTests.Single_query_with_collection_navigation_to_readonly_entity.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Single_query_with_collection_navigation_to_readonly_entity.verified.txt
@@ -16,13 +16,13 @@
   sql: {
     Text:
 select   r1.Id,
-         r1.Property,
          r0.Id,
          r0.Age,
          r0.ComputedInDb,
          r0.FirstName,
          r0.LastName,
-         r0.ReadOnlyParentId
+         r0.ReadOnlyParentId,
+         r1.Property
 from     (select top (2) r.Id,
                          r.Property
           from   ReadOnlyParentEntities as r

--- a/src/Tests/IntegrationTests/IntegrationTests.With_null_navigation_property.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.With_null_navigation_property.verified.txt
@@ -20,11 +20,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/IntegrationTests/IntegrationTests.With_null_navigation_property_notEqual.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.With_null_navigation_property_notEqual.verified.txt
@@ -12,11 +12,11 @@
   sql: {
     Text:
 select   c.Id,
-         c.ParentId,
-         c.Property,
          case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
          p.Id,
-         p.Property
+         p.Property,
+         c.ParentId,
+         c.Property
 from     ChildEntities as c
          left outer join
          ParentEntities as p

--- a/src/Tests/SelectExpressionBuilderTests.cs
+++ b/src/Tests/SelectExpressionBuilderTests.cs
@@ -1,0 +1,47 @@
+﻿public class SelectExpressionBuilderTests
+{
+    public class Target
+    {
+        public int Id { get; set; }
+        public string? Alpha { get; set; }
+        public string? Beta { get; set; }
+        public string? Gamma { get; set; }
+    }
+
+    static readonly Dictionary<Type, List<string>> keyNames = new()
+    {
+        {
+            typeof(Target), ["Id"]
+        }
+    };
+
+    static Expression<Func<Target, Target>> Build(params string[] scalarFields)
+    {
+        var projection = new FieldProjectionInfo(
+            new(scalarFields, StringComparer.OrdinalIgnoreCase),
+            ["Id"],
+            null,
+            null);
+        Assert.True(SelectExpressionBuilder.TryBuild<Target>(projection, keyNames, out var expression));
+        return expression!;
+    }
+
+    [Fact]
+    public void FieldOrderDoesNotChangeTheExpression()
+    {
+        // The same fields requested in a different order must produce the same tree, otherwise EF
+        // caches a separate compiled query for identical work.
+        var forward = Build("Alpha", "Beta", "Gamma");
+        var reversed = Build("Gamma", "Beta", "Alpha");
+        var shuffled = Build("Beta", "Gamma", "Alpha");
+
+        Assert.Equal(forward.ToString(), reversed.ToString());
+        Assert.Equal(forward.ToString(), shuffled.ToString());
+    }
+
+    [Fact]
+    public void DifferentFieldSetsStillDiffer() =>
+        Assert.NotEqual(
+            Build("Alpha", "Beta").ToString(),
+            Build("Alpha", "Gamma").ToString());
+}


### PR DESCRIPTION
## Problem

Bindings were collected in the order the fields arrived — keys, then foreign keys, then scalars in `HashSet` insertion order, then navigations in `Dictionary` insertion order. The last two follow the order the fields appear in the GraphQL query.

EF keys its compiled query cache on the structure of the expression tree, so:

```graphql
{ id property }     ->   one compiled query
{ property id }     ->   a second compiled query, for identical work
```

With *n* scalar fields there are up to *n!* distinct trees for the same projection.

## Fix

Sort by member name before building the `MemberInit`, in both the root builder and the nested navigation builder. Between them those cover all five `MemberInit` sites, so nested projections are canonical too.

Binding order carries no meaning here — the target is a fresh object with no interdependencies between assignments — so the only visible effect is the column order of the generated `select`.

## About the 77 changed snapshots

All 77 are column reordering inside the generated sql. I verified this rather than assuming it: every received/verified pair was compared with the sql section split off, and **every data section is byte identical**. 72 matched that split directly; the remaining 5 nest their sql differently and were read by hand.

## Tests

`SelectExpressionBuilderTests` covers this directly rather than through the GraphQL layer:

- `FieldOrderDoesNotChangeTheExpression` builds the same three non-key scalars in three different orders and asserts one tree.
- `DifferentFieldSetsStillDiffer` guards the obvious way to "pass" the first test by collapsing genuinely different projections.

Worth noting why it is a unit test and not an integration one. My first attempt compared the generated sql for `{id property}` against `{property id}` and passed *without* the fix: the key is always emitted first, so with a single non-key field the order cannot vary. Three non-key scalars are needed to exercise it, and the unit test fails without the sort and passes with it.
