### PR TITLE
Cache reflection lookups and fix the page info overflow

### DIFF
--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -1,4 +1,4 @@
-static class ConnectionConverter
+﻿static class ConnectionConverter
 {
     internal static bool HasOrderingInExpressionTree(Expression expression)
     {
@@ -235,10 +235,11 @@ static class ConnectionConverter
             Edges = edges,
             PageInfo = new()
             {
-                HasNextPage = count > take + skip,
+                // long, since a large `first` makes take + skip overflow and wrap negative
+                HasNextPage = count > (long) take + skip,
                 HasPreviousPage = skip > 0,
                 StartCursor = skip.ToString(),
-                EndCursor = Math.Min(count - 1, take - 1 + skip).ToString()
+                EndCursor = Math.Min(count - 1, (long) take - 1 + skip).ToString()
             }
         };
     }

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -1,4 +1,4 @@
-class IncludeAppender(
+﻿class IncludeAppender(
     IReadOnlyDictionary<Type, IReadOnlyDictionary<string, Navigation>> navigations,
     IReadOnlyDictionary<Type, List<string>> keyNames,
     IReadOnlyDictionary<Type, IReadOnlySet<string>> foreignKeys)
@@ -134,14 +134,24 @@ class IncludeAppender(
         return query;
     }
 
+    static MethodInfo includeMethodDefinition = typeof(EntityFrameworkQueryableExtensions)
+        .GetMethods(BindingFlags.Static | BindingFlags.Public)
+        .First(_ => _.Name == "Include" &&
+                    _.GetGenericArguments().Length == 2 &&
+                    _.GetParameters().Length == 2 &&
+                    _.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>));
+
+    static ConcurrentDictionary<(Type entity, Type property), MethodInfo> includeMethods = new();
+
+    /// <summary>
+    /// Both the scan over every public static method on EntityFrameworkQueryableExtensions and the
+    /// MakeGenericMethod were being repeated per request. The pairs are bounded by the model, so
+    /// they are safe to hold on to.
+    /// </summary>
     static MethodInfo GetIncludeMethod(Type entityType, Type propertyType) =>
-        typeof(EntityFrameworkQueryableExtensions)
-            .GetMethods(BindingFlags.Static | BindingFlags.Public)
-            .First(_ => _.Name == "Include" &&
-                        _.GetGenericArguments().Length == 2 &&
-                        _.GetParameters().Length == 2 &&
-                        _.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>))
-            .MakeGenericMethod(entityType, propertyType);
+        includeMethods.GetOrAdd(
+            (entityType, propertyType),
+            _ => includeMethodDefinition.MakeGenericMethod(_.entity, _.property));
 
     static IQueryable<TItem> AddNestedIncludes<TItem>(
         IQueryable<TItem> query,
@@ -384,7 +394,8 @@ class IncludeAppender(
         clrType = null;
 
         // Use the schema's type lookup to resolve GraphQL type name → CLR type
-        var graphType = schema.AllTypes.FirstOrDefault(_ => _.Name == graphQlTypeName);
+        // Indexed by name, rather than a linear scan of every type in the schema per request
+        var graphType = schema.AllTypes[graphQlTypeName];
         if (graphType is not null)
         {
             // Walk the type hierarchy to find the CLR type from the generic arguments

--- a/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
@@ -1,4 +1,4 @@
-namespace GraphQL.EntityFramework;
+﻿namespace GraphQL.EntityFramework;
 
 static class SelectExpressionBuilder
 {
@@ -19,7 +19,17 @@ static class SelectExpressionBuilder
 
     static ConcurrentDictionary<Type, EntityTypeMetadata> entityMetadataCache = new();
 
-    record PropertyMetadata(PropertyInfo Property, bool CanWrite, bool IsAutoProperty, MemberExpression PropertyAccess, MemberBinding? Binding, MethodInfo OrderByMethod);
+    record PropertyMetadata(Type EntityType, PropertyInfo Property, bool CanWrite, bool IsAutoProperty, MemberExpression PropertyAccess, MemberBinding? Binding)
+    {
+        MethodInfo? cachedOrderBy;
+
+        /// <summary>
+        /// Only the key property of a collection navigation ever needs this, but it was being
+        /// constructed for every property of every entity type. MakeGenericMethod is not free.
+        /// </summary>
+        public MethodInfo OrderByMethod =>
+            cachedOrderBy ??= orderByMethod.MakeGenericMethod(EntityType, Property.PropertyType);
+    }
 
     record EntityTypeMetadata(
         ParameterExpression Parameter,
@@ -452,8 +462,7 @@ static class SelectExpressionBuilder
                 var isAutoProperty = canWrite &&
                                      property.SetMethod!.IsDefined(typeof(CompilerGeneratedAttribute), false);
                 var binding = canWrite ? Expression.Bind(property, propertyAccess) : null;
-                var orderByMethod = SelectExpressionBuilder.orderByMethod.MakeGenericMethod(type, property.PropertyType);
-                dictionary[property.Name] = new(property, canWrite, isAutoProperty, propertyAccess, binding, orderByMethod);
+                dictionary[property.Name] = new(type, property, canWrite, isAutoProperty, propertyAccess, binding);
             }
 
             var newInstance = Expression.New(type);

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
@@ -116,6 +116,16 @@
     }
 
     [Fact]
+    public void Large_first_does_not_overflow_page_info()
+    {
+        // take + skip overflowed to negative, so HasNextPage reported true on a fully covered page
+        var connection = ConnectionConverter.ApplyConnectionContext(list, int.MaxValue, after: 0, last: null, before: null);
+
+        Assert.False(connection.PageInfo!.HasNextPage);
+        Assert.Equal("9", connection.PageInfo.EndCursor);
+    }
+
+    [Fact]
     public void List_after_is_an_exclusive_cursor()
     {
         // 'after' is an exclusive cursor: results start strictly after the given index,


### PR DESCRIPTION
Four small items, all per request work that did not need to be.

## GetIncludeMethod

Scanned every public static method on `EntityFrameworkQueryableExtensions` and then called `MakeGenericMethod`, once per derived navigation per request. The scan is hoisted to a static, and the constructed methods are memoised. Both the open definition and the `(entity, property)` pairs are bounded by the model, so there is nothing client driven to grow with.

## GetEntityMetadata

Built an `OrderBy` `MethodInfo` for *every* property of every entity type:

```csharp
var orderByMethod = SelectExpressionBuilder.orderByMethod.MakeGenericMethod(type, property.PropertyType);
```

Only the key property of a collection navigation ever uses one, so on a wide entity nearly all of them were wasted. Deferred to first access.

## TryFindDerivedClrType

Linear scanned `schema.AllTypes` per request. `SchemaTypes` exposes a name indexer, so this is now a lookup.

## Page info overflow

`HasNextPage` computed `count > take + skip`. With a large `first` that overflows to negative, and `count > negative` is always true, so a fully covered page reported a further page. `EndCursor` had the same problem. Both now compute in `long`.

This is the only one of the four with observable behaviour, so it is the only one with a test. `Large_first_does_not_overflow_page_info` asserts `HasNextPage` is false for `first: int.MaxValue` over a covered range; without the fix it is true.

The other three are pure caching with no behavioural change, covered by the existing suite.
