### PR TITLE
Resolve where and orderBy paths against public members only

### DIFF
--- a/src/GraphQL.EntityFramework/PropertyAccess/PropertyCache.cs
+++ b/src/GraphQL.EntityFramework/PropertyAccess/PropertyCache.cs
@@ -100,19 +100,15 @@
 
     static MemberInfo? TryGetPropertyOrField(Type type, string propertyOrFieldName)
     {
-        // Member search binding flags
+        // Member search binding flags.
+        // Only public members are resolved. Paths arrive from the client, so falling back to
+        // non public members would make anything the clr can read filterable, including members
+        // deliberately kept out of the graph.
         const BindingFlags bindingFlagsPublic = BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy;
-        const BindingFlags bindingFlagsNonPublic = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy;
 
         // Attempt to get the public property
         var propertyOrField = type.GetProperty(propertyOrFieldName, bindingFlagsPublic) ??
                               (MemberInfo?)type.GetField(propertyOrFieldName, bindingFlagsPublic);
-
-        // If not found
-        propertyOrField ??= type.GetProperty(propertyOrFieldName, bindingFlagsNonPublic);
-
-        // If not found
-        propertyOrField ??= type.GetField(propertyOrFieldName, bindingFlagsNonPublic);
 
         // If property/field was not resolved, search inherited interfaces.
         // Interface member lookup is not flattened, so each base interface must be

--- a/src/Tests/PropertyCacheTests.cs
+++ b/src/Tests/PropertyCacheTests.cs
@@ -1,4 +1,4 @@
-﻿public class PropertyCacheTests
+﻿﻿public class PropertyCacheTests
 {
     [Fact]
     public void Property()
@@ -122,6 +122,47 @@
     {
         public SelfReferencing? Self { get; set; }
         public string? Public { get; set; }
+    }
+
+    [Theory]
+    // paths come from the client, so non public members must not be resolvable
+    [InlineData("secretField")]
+    [InlineData("SecretProperty")]
+    // resolution is case insensitive, so casing must not be a way around it
+    [InlineData("SECRETFIELD")]
+    [InlineData("secretproperty")]
+    // nor may they be reached through a nested path
+    [InlineData("Child.secretField")]
+    public void NonPublicMembersAreNotResolved(string path)
+    {
+        var exception = Assert.Throws<Exception>(() => PropertyCache<TargetWithNonPublicMembers>.GetProperty(path));
+        Assert.Contains("Failed to create a member expression", exception.Message);
+    }
+
+    [Fact]
+    public void PublicMembersStillResolveOnTypeWithNonPublicMembers()
+    {
+        var target = new TargetWithNonPublicMembers
+        {
+            Public = "Value1"
+        };
+
+        var property = PropertyCache<TargetWithNonPublicMembers>.GetProperty("Public");
+        Assert.Equal("Value1", property.Func(target));
+    }
+
+    public class TargetWithNonPublicMembers
+    {
+        public string? Public { get; set; }
+        public TargetWithNonPublicMembers? Child { get; set; }
+
+        // ReSharper disable once UnusedMember.Local
+        string? secretField = "hunter2";
+
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        string? SecretProperty { get; set; } = "top-secret";
+
+        public string? ReadNonPublic() => secretField + SecretProperty;
     }
 
     public interface IHasA


### PR DESCRIPTION
TryGetPropertyOrField fell back to BindingFlags.NonPublic, so a client supplied `path` could name a private or internal field or property of a mapped entity, including members deliberately kept out of the graph. Since a where clause is a boolean predicate, that is an oracle: repeated startsWith probes recover a value one character at a time.

IgnoreCase made it worse, as the exact casing of the member was not needed.

Drop the non public lookup. Paths now resolve against public members only, and an unresolved path raises the existing "is not a member of type" error.

This is a behavioural break for anyone deliberately filtering on a non public member, which needs a release note.