### PR TITLE
Project nested connections, projection based fields, fragments and repeated selections below the root

### DIFF
--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -22,7 +22,7 @@
         keyNames.TryGetValue(type, out var keys);
         foreignKeys.TryGetValue(type, out var fks);
 
-        var projection = GetProjectionInfo(context, navigationProperties, keys, fks);
+        var projection = GetProjectionInfo(context, type, navigationProperties, keys, fks);
 
         if (filters is { HasFilters: true })
         {
@@ -49,7 +49,7 @@
         keyNames.TryGetValue(type, out var keys);
         foreignKeys.TryGetValue(type, out var fks);
 
-        var projection = GetProjectionInfo(context, navigationProperties, keys, fks);
+        var projection = GetProjectionInfo(context, type, navigationProperties, keys, fks);
 
         if (filters is { HasFilters: true })
         {
@@ -224,6 +224,7 @@
 
     FieldProjectionInfo GetProjectionInfo(
         IResolveFieldContext context,
+        Type entityType,
         IReadOnlyDictionary<string, Navigation>? navigationProperties,
         List<string>? keys,
         IReadOnlySet<string>? foreignKeyNames)
@@ -233,32 +234,93 @@
 
         if (context.SubFields is not null)
         {
-            foreach (var fieldInfo in context.SubFields.Values)
+            foreach (var (field, fieldType) in context.SubFields.Values)
             {
-                // SubFields is keyed by response key, which is the alias when one is used.
-                // The name of the property to project has to come from the ast node.
-                var fieldName = fieldInfo.Field.Name.StringValue;
-                if (IsConnectionNodeName(fieldName))
-                {
-                    ProcessConnectionNodeFields(fieldInfo.Field.SelectionSet, navigationProperties, scalarFields, navProjections, context);
-                }
-                else
-                {
-                    ProcessProjectionField(fieldName, fieldInfo, navigationProperties, scalarFields, navProjections, context);
-                }
+                ProcessField(field, fieldType, navigationProperties, scalarFields, navProjections, context);
             }
         }
 
         // Scan for derived-type navigations from inline fragments (TPH support)
-        var derivedNavigations = GetDerivedNavigationsFromFragments(context);
+        var derivedNavigations = GetDerivedNavigationsFromFragments(context, entityType);
 
         return new(scalarFields, keys, foreignKeyNames, navProjections, derivedNavigations);
     }
 
-    Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? GetDerivedNavigationsFromFragments(
+    /// <summary>
+    /// The field type carries the projection metadata, and its resolved graph type is what the
+    /// selection set below it selects from. GraphQL.NET supplies both for the root sub fields
+    /// only, so for nested selection sets they are recovered by walking the schema alongside
+    /// the ast. Without that, a projection based field or a connection below the root was
+    /// treated as a scalar named after the field, and nothing under it was projected.
+    /// </summary>
+    void ProcessField(
+        GraphQLField field,
+        FieldType? fieldType,
+        IReadOnlyDictionary<string, Navigation>? navigationProperties,
+        HashSet<string> scalarFields,
+        Dictionary<string, NavigationProjectionInfo> navProjections,
         IResolveFieldContext context)
     {
-        var selectionSet = GetLeafSelectionSet(context);
+        // SubFields is keyed by response key, which is the alias when one is used.
+        // The name of the property to project has to come from the ast node.
+        var fieldName = field.Name.StringValue;
+
+        if (IsConnectionNodeName(fieldName))
+        {
+            // edges, items and node are wrappers with no property of their own.
+            // The entity fields are in the selection set below them.
+            ProcessSelectionSet(field.SelectionSet, GetComplexGraphType(fieldType), navigationProperties, scalarFields, navProjections, context);
+            return;
+        }
+
+        if (fieldType is not null &&
+            TryGetProjectionMetadata(fieldType, out var projection))
+        {
+            ProcessProjectionExpression(field, fieldType, projection, navigationProperties, scalarFields, navProjections, context);
+            return;
+        }
+
+        ProcessNavigationOrScalar(fieldName, field, fieldType, navigationProperties, scalarFields, navProjections, context);
+    }
+
+    void ProcessSelectionSet(
+        GraphQLSelectionSet? selectionSet,
+        IComplexGraphType? graphType,
+        IReadOnlyDictionary<string, Navigation>? navigationProperties,
+        HashSet<string> scalarFields,
+        Dictionary<string, NavigationProjectionInfo> navProjections,
+        IResolveFieldContext context)
+    {
+        if (selectionSet?.Selections is null)
+        {
+            return;
+        }
+
+        foreach (var (field, fieldGraphType) in EnumerateFields(selectionSet, graphType, context))
+        {
+            var fieldType = fieldGraphType?.GetField(field.Name.Value);
+            ProcessField(field, fieldType, navigationProperties, scalarFields, navProjections, context);
+        }
+    }
+
+    /// <summary>
+    /// The graph type a field's selection set selects from. Null for a scalar or a field that could
+    /// not be resolved, in which case the selection set is matched against the entity by name alone.
+    /// </summary>
+    static IComplexGraphType? GetComplexGraphType(FieldType? fieldType) =>
+        fieldType?.ResolvedType?.GetNamedType() as IComplexGraphType;
+
+    /// <summary>
+    /// Navigations selected through a fragment on a type derived from the entity type. They do
+    /// not exist on the entity type itself, so they are collected per derived type and included
+    /// with a cast. Fragments on the entity type itself, or on one of its base types, select
+    /// navigations the main projection already covers, so they are skipped.
+    /// </summary>
+    Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? GetDerivedNavigationsFromFragments(
+        IResolveFieldContext context,
+        Type entityType)
+    {
+        var (selectionSet, leafGraphType) = GetLeafSelection(context);
         if (selectionSet?.Selections is null)
         {
             return null;
@@ -266,86 +328,43 @@
 
         Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? result = null;
 
-        foreach (var selection in selectionSet.Selections)
+        foreach (var (field, fieldGraphType) in EnumerateFields(selectionSet, leafGraphType, context))
         {
-            GraphQLTypeCondition? typeCondition;
-            GraphQLSelectionSet? fragmentSelectionSet;
-
-            switch (selection)
-            {
-                case GraphQLInlineFragment inlineFragment:
-                    typeCondition = inlineFragment.TypeCondition;
-                    fragmentSelectionSet = inlineFragment.SelectionSet;
-                    break;
-                case GraphQLFragmentSpread fragmentSpread:
-                {
-                    var name = fragmentSpread.FragmentName.Name;
-                    var fragmentDefinition = context.Document.Definitions
-                        .OfType<GraphQLFragmentDefinition>()
-                        .SingleOrDefault(_ => _.FragmentName.Name == name);
-                    if (fragmentDefinition is null)
-                    {
-                        continue;
-                    }
-
-                    typeCondition = fragmentDefinition.TypeCondition;
-                    fragmentSelectionSet = fragmentDefinition.SelectionSet;
-                    break;
-                }
-                default:
-                    continue;
-            }
-
-            if (typeCondition is null)
+            if (fieldGraphType is null ||
+                ReferenceEquals(fieldGraphType, leafGraphType) ||
+                !TryFindDerivedClrType(fieldGraphType, out var derivedType) ||
+                derivedType == entityType ||
+                !entityType.IsAssignableFrom(derivedType))
             {
                 continue;
             }
 
-            var typeName = typeCondition.Type.Name.StringValue;
-
-            // Find the CLR type for this GraphQL type name using the schema
-            if (!TryFindDerivedClrType(typeName, context.Schema, out var derivedType))
+            if (!navigations.TryGetValue(derivedType, out var derivedNavProps) ||
+                !derivedNavProps.TryGetValue(field.Name.StringValue, out var navigation))
             {
                 continue;
             }
 
-            // Get navigation properties for this derived type
-            if (!navigations.TryGetValue(derivedType, out var derivedNavProps))
+            result ??= [];
+            if (!result.TryGetValue(derivedType, out var derivedNavs))
             {
-                continue;
+                derivedNavs = [];
+                result[derivedType] = derivedNavs;
             }
 
-            // Process fields in this fragment against the derived type's navigation properties
-            foreach (var field in fragmentSelectionSet.Selections.OfType<GraphQLField>())
-            {
-                var fieldName = field.Name.StringValue;
-                if (!derivedNavProps.TryGetValue(fieldName, out var navigation))
-                {
-                    continue;
-                }
+            var navType = navigation.Type;
+            navigations.TryGetValue(navType, out var nestedNavProps);
+            keyNames.TryGetValue(navType, out var nestedKeys);
+            foreignKeys.TryGetValue(navType, out var nestedFks);
 
-                result ??= [];
-                if (!result.TryGetValue(derivedType, out var derivedNavs))
-                {
-                    derivedNavs = [];
-                    result[derivedType] = derivedNavs;
-                }
-
-                if (derivedNavs.ContainsKey(navigation.Name))
-                {
-                    continue;
-                }
-
-                var navType = navigation.Type;
-                navigations.TryGetValue(navType, out var nestedNavProps);
-                keyNames.TryGetValue(navType, out var nestedKeys);
-                foreignKeys.TryGetValue(navType, out var nestedFks);
-
-                derivedNavs[navigation.Name] = new(
+            var navGraphType = GetComplexGraphType(fieldGraphType.GetField(field.Name.Value));
+            AddNavigation(
+                derivedNavs,
+                navigation.Name,
+                new(
                     navType,
                     navigation.IsCollection,
-                    GetNestedProjection(field.SelectionSet, nestedNavProps, nestedKeys, nestedFks, context));
-            }
+                    GetNestedProjection(field.SelectionSet, navGraphType, nestedNavProps, nestedKeys, nestedFks, context)));
         }
 
         return result;
@@ -353,15 +372,17 @@
 
     /// <summary>
     /// Navigate through connection wrapper fields (edges/items/node) to find the leaf selection set
-    /// that contains the actual entity fields and inline fragments.
+    /// that contains the actual entity fields and inline fragments, and the graph type it selects from.
     /// </summary>
-    static GraphQLSelectionSet? GetLeafSelectionSet(IResolveFieldContext context)
+    static (GraphQLSelectionSet? SelectionSet, IComplexGraphType? GraphType) GetLeafSelection(IResolveFieldContext context)
     {
         var selectionSet = context.FieldAst.SelectionSet;
         if (selectionSet?.Selections is null)
         {
-            return null;
+            return (null, null);
         }
+
+        var graphType = GetComplexGraphType(context.FieldDefinition);
 
         // Drill through connection wrapper fields
         while (true)
@@ -369,14 +390,13 @@
             var found = false;
             foreach (var selection in selectionSet.Selections)
             {
-                if (selection is GraphQLField field && IsConnectionNodeName(field.Name.StringValue))
+                if (selection is GraphQLField { SelectionSet: not null } field &&
+                    IsConnectionNodeName(field.Name.StringValue))
                 {
-                    if (field.SelectionSet is not null)
-                    {
-                        selectionSet = field.SelectionSet;
-                        found = true;
-                        break;
-                    }
+                    graphType = GetComplexGraphType(graphType?.GetField(field.Name.Value));
+                    selectionSet = field.SelectionSet;
+                    found = true;
+                    break;
                 }
             }
 
@@ -386,31 +406,25 @@
             }
         }
 
-        return selectionSet;
+        return (selectionSet, graphType);
     }
 
-    bool TryFindDerivedClrType(string graphQlTypeName, ISchema schema, [NotNullWhen(true)] out Type? clrType)
+    bool TryFindDerivedClrType(IGraphType graphType, [NotNullWhen(true)] out Type? clrType)
     {
         clrType = null;
 
-        // Use the schema's type lookup to resolve GraphQL type name → CLR type
-        // Indexed by name, rather than a linear scan of every type in the schema per request
-        var graphType = schema.AllTypes[graphQlTypeName];
-        if (graphType is not null)
+        // Walk the type hierarchy to find the CLR type from the generic arguments
+        var graphClrType = GetSourceType(graphType.GetType());
+        if (graphClrType is not null && navigations.ContainsKey(graphClrType))
         {
-            // Walk the type hierarchy to find the CLR type from the generic arguments
-            var graphClrType = GetSourceType(graphType.GetType());
-            if (graphClrType is not null && navigations.ContainsKey(graphClrType))
-            {
-                clrType = graphClrType;
-                return true;
-            }
+            clrType = graphClrType;
+            return true;
         }
 
         // Fallback: match CLR type name directly
         foreach (var type in navigations.Keys)
         {
-            if (string.Equals(type.Name, graphQlTypeName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(type.Name, graphType.Name, StringComparison.OrdinalIgnoreCase))
             {
                 clrType = type;
                 return true;
@@ -441,56 +455,14 @@
         return null;
     }
 
-    void ProcessConnectionNodeFields(
-        GraphQLSelectionSet? selectionSet,
-        IReadOnlyDictionary<string, Navigation>? navigationProperties,
-        HashSet<string> scalarFields,
-        Dictionary<string, NavigationProjectionInfo> navProjections,
-        IResolveFieldContext context)
-    {
-        if (selectionSet?.Selections is null)
-        {
-            return;
-        }
-
-        foreach (var selection in EnumerateFields(selectionSet, context))
-        {
-            var fieldName = selection.Name.StringValue;
-            if (IsConnectionNodeName(fieldName))
-            {
-                ProcessConnectionNodeFields(selection.SelectionSet, navigationProperties, scalarFields, navProjections, context);
-            }
-            else
-            {
-                ProcessNestedProjectionField(fieldName, selection, navigationProperties, scalarFields, navProjections, context);
-            }
-        }
-    }
-
     static bool IsConnectionNodeName(string fieldName) =>
         fieldName.Equals("edges", StringComparison.OrdinalIgnoreCase) ||
         fieldName.Equals("items", StringComparison.OrdinalIgnoreCase) ||
         fieldName.Equals("node", StringComparison.OrdinalIgnoreCase);
 
-    void ProcessProjectionField(
-        string fieldName,
-        (GraphQLField Field, FieldType FieldType) fieldInfo,
-        IReadOnlyDictionary<string, Navigation>? navigationProperties,
-        HashSet<string> scalarFields,
-        Dictionary<string, NavigationProjectionInfo> navProjections,
-        IResolveFieldContext context)
-    {
-        if (TryGetProjectionMetadata(fieldInfo.FieldType, out var projection))
-        {
-            ProcessProjectionExpression(fieldInfo, projection, navigationProperties, scalarFields, navProjections, context);
-            return;
-        }
-
-        ProcessNestedProjectionField(fieldName, fieldInfo.Field, navigationProperties, scalarFields, navProjections, context);
-    }
-
     void ProcessProjectionExpression(
-        (GraphQLField Field, FieldType FieldType) fieldInfo,
+        GraphQLField field,
+        FieldType fieldType,
         LambdaExpression projection,
         IReadOnlyDictionary<string, Navigation>? navigationProperties,
         HashSet<string> scalarFields,
@@ -524,15 +496,10 @@
 
         foreach (var (navName, nestedPaths) in pathsByNavigation)
         {
-            if (!TryFindNavigation(navigationProperties, navName, out var navigation, out var actualNavName))
+            if (!TryFindNavigation(navigationProperties, navName, out var navigation))
             {
                 // Scalar field path (no navigation) — add root property to scalarFields
                 scalarFields.Add(navName);
-                continue;
-            }
-
-            if (navProjections.ContainsKey(actualNavName))
-            {
                 continue;
             }
 
@@ -546,7 +513,7 @@
             if (navName == primaryNavigation)
             {
                 // Primary navigation: merge GraphQL fields with projection-required fields
-                nestedProjection = GetNestedProjection(fieldInfo.Field.SelectionSet, nestedNavProps, nestedKeys, nestedFks, context);
+                nestedProjection = GetNestedProjection(field.SelectionSet, GetComplexGraphType(fieldType), nestedNavProps, nestedKeys, nestedFks, context);
                 foreach (var nestedPath in nestedPaths)
                 {
                     if (!nestedPath.Contains('.'))
@@ -565,45 +532,23 @@
                 nestedProjection = new(nestedScalarFields, nestedKeys ?? [], nestedFks ?? new HashSet<string>(), []);
             }
 
-            navProjections[actualNavName] = new(navType, navigation.IsCollection, nestedProjection);
+            AddNavigation(navProjections, navigation.Name, new(navType, navigation.IsCollection, nestedProjection));
         }
     }
 
     static bool TryFindNavigation(
         IReadOnlyDictionary<string, Navigation>? properties,
         string name,
-        [NotNullWhen(true)] out Navigation? navigation,
-        [NotNullWhen(true)] out string? actualName)
+        [NotNullWhen(true)] out Navigation? navigation)
     {
         navigation = null;
-        actualName = null;
-
-        if (properties == null)
-        {
-            return false;
-        }
-
-        if (properties.TryGetValue(name, out navigation))
-        {
-            actualName = name;
-            return true;
-        }
-
-        foreach (var (key, value) in properties)
-        {
-            if (string.Equals(key, name, StringComparison.OrdinalIgnoreCase))
-            {
-                navigation = value;
-                actualName = key;
-                return true;
-            }
-        }
-
-        return false;
+        return properties is not null &&
+               properties.TryGetValue(name, out navigation);
     }
 
     FieldProjectionInfo GetNestedProjection(
         GraphQLSelectionSet? selectionSet,
+        IComplexGraphType? graphType,
         IReadOnlyDictionary<string, Navigation>? navigationProperties,
         List<string>? keys,
         IReadOnlySet<string>? foreignKeyNames,
@@ -612,35 +557,40 @@
         var scalarFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var navProjections = new Dictionary<string, NavigationProjectionInfo>();
 
-        if (selectionSet?.Selections is null)
-        {
-            return new(scalarFields, keys, foreignKeyNames, navProjections);
-        }
-
-        foreach (var field in EnumerateFields(selectionSet, context))
-        {
-            ProcessNestedProjectionField(field.Name.StringValue, field, navigationProperties, scalarFields, navProjections, context);
-        }
+        ProcessSelectionSet(selectionSet, graphType, navigationProperties, scalarFields, navProjections, context);
 
         return new(scalarFields, keys, foreignKeyNames, navProjections);
     }
 
-    static IEnumerable<GraphQLField> EnumerateFields(GraphQLSelectionSet selectionSet, IResolveFieldContext context)
+    /// <summary>
+    /// The fields in a selection set, including those inside fragments at any depth. A fragment
+    /// can name a type other than the parent's, so each field is paired with the graph type it
+    /// selects from. Validation rejects fragment cycles, but they are guarded against anyway,
+    /// since the recursion would otherwise never end.
+    /// </summary>
+    static IEnumerable<(GraphQLField Field, IComplexGraphType? GraphType)> EnumerateFields(
+        GraphQLSelectionSet selectionSet,
+        IComplexGraphType? graphType,
+        IResolveFieldContext context,
+        HashSet<string>? spreadsInProgress = null)
     {
         foreach (var selection in selectionSet.Selections)
         {
             switch (selection)
             {
                 case GraphQLField field:
-                    yield return field;
+                    yield return (field, graphType);
                     break;
                 case GraphQLInlineFragment inlineFragment:
-                    foreach (var field in inlineFragment.SelectionSet.Selections.OfType<GraphQLField>())
+                {
+                    var fragmentGraphType = ResolveTypeCondition(inlineFragment.TypeCondition, graphType, context);
+                    foreach (var item in EnumerateFields(inlineFragment.SelectionSet, fragmentGraphType, context, spreadsInProgress))
                     {
-                        yield return field;
+                        yield return item;
                     }
 
                     break;
+                }
                 case GraphQLFragmentSpread fragmentSpread:
                 {
                     var name = fragmentSpread.FragmentName.Name;
@@ -653,20 +603,42 @@
                         break;
                     }
 
-                    foreach (var field in fragmentDefinition.SelectionSet.Selections.OfType<GraphQLField>())
+                    spreadsInProgress ??= [];
+                    if (!spreadsInProgress.Add(name.StringValue))
                     {
-                        yield return field;
+                        break;
                     }
 
+                    var fragmentGraphType = ResolveTypeCondition(fragmentDefinition.TypeCondition, graphType, context);
+                    foreach (var item in EnumerateFields(fragmentDefinition.SelectionSet, fragmentGraphType, context, spreadsInProgress))
+                    {
+                        yield return item;
+                    }
+
+                    spreadsInProgress.Remove(name.StringValue);
                     break;
                 }
             }
         }
     }
 
-    void ProcessNestedProjectionField(
+    static IComplexGraphType? ResolveTypeCondition(
+        GraphQLTypeCondition? typeCondition,
+        IComplexGraphType? parentGraphType,
+        IResolveFieldContext context)
+    {
+        if (typeCondition is null)
+        {
+            return parentGraphType;
+        }
+
+        return context.Schema.AllTypes[typeCondition.Type.Name.StringValue] as IComplexGraphType ?? parentGraphType;
+    }
+
+    void ProcessNavigationOrScalar(
         string fieldName,
         GraphQLField field,
+        FieldType? fieldType,
         IReadOnlyDictionary<string, Navigation>? navigationProperties,
         HashSet<string> scalarFields,
         Dictionary<string, NavigationProjectionInfo> navProjections,
@@ -686,11 +658,28 @@
         keyNames.TryGetValue(navType, out var nestedKeys);
         foreignKeys.TryGetValue(navType, out var nestedFks);
 
-        navProjections[navigation.Name] = new(
-            navType,
-            navigation.IsCollection,
-            GetNestedProjection(field.SelectionSet, nestedNavProps, nestedKeys, nestedFks, context));
+        AddNavigation(
+            navProjections,
+            navigation.Name,
+            new(
+                navType,
+                navigation.IsCollection,
+                GetNestedProjection(field.SelectionSet, GetComplexGraphType(fieldType), nestedNavProps, nestedKeys, nestedFks, context)));
     }
+
+    /// <summary>
+    /// The same navigation can be selected more than once: under two aliases, through a fragment
+    /// as well as directly, or by a projection based field alongside the navigation field itself.
+    /// Each selection can ask for different fields, so they are merged rather than the first or
+    /// the last one winning.
+    /// </summary>
+    static void AddNavigation(
+        Dictionary<string, NavigationProjectionInfo> navProjections,
+        string name,
+        NavigationProjectionInfo navProjection) =>
+        navProjections[name] = navProjections.TryGetValue(name, out var existing)
+            ? existing.Merge(navProjection)
+            : navProjection;
 
     public static void SetProjectionMetadata(FieldType fieldType, LambdaExpression projection) =>
         fieldType.Metadata["_EF_Projection"] = projection;

--- a/src/GraphQL.EntityFramework/SelectProjection/FieldProjectionInfo.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/FieldProjectionInfo.cs
@@ -3,4 +3,72 @@ record FieldProjectionInfo(
     List<string>? KeyNames,
     IReadOnlySet<string>? ForeignKeyNames,
     Dictionary<string, NavigationProjectionInfo>? Navigations,
-    Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? DerivedNavigations = null);
+    Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? DerivedNavigations = null)
+{
+    /// <summary>
+    /// Combine two projections of the same entity type, so that a field requested by either is
+    /// projected. Navigations present in both are merged recursively.
+    /// </summary>
+    public FieldProjectionInfo Merge(FieldProjectionInfo other)
+    {
+        var scalarFields = new HashSet<string>(ScalarFields, StringComparer.OrdinalIgnoreCase);
+        scalarFields.UnionWith(other.ScalarFields);
+
+        return new(
+            scalarFields,
+            KeyNames ?? other.KeyNames,
+            ForeignKeyNames ?? other.ForeignKeyNames,
+            MergeNavigations(Navigations, other.Navigations),
+            MergeDerivedNavigations(DerivedNavigations, other.DerivedNavigations));
+    }
+
+    static Dictionary<string, NavigationProjectionInfo>? MergeNavigations(
+        Dictionary<string, NavigationProjectionInfo>? left,
+        Dictionary<string, NavigationProjectionInfo>? right)
+    {
+        if (left is null)
+        {
+            return right;
+        }
+
+        if (right is null)
+        {
+            return left;
+        }
+
+        var merged = new Dictionary<string, NavigationProjectionInfo>(left);
+        foreach (var (name, navigation) in right)
+        {
+            merged[name] = merged.TryGetValue(name, out var existing)
+                ? existing.Merge(navigation)
+                : navigation;
+        }
+
+        return merged;
+    }
+
+    static Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? MergeDerivedNavigations(
+        Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? left,
+        Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? right)
+    {
+        if (left is null)
+        {
+            return right;
+        }
+
+        if (right is null)
+        {
+            return left;
+        }
+
+        var merged = new Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>(left);
+        foreach (var (type, navigations) in right)
+        {
+            merged[type] = merged.TryGetValue(type, out var existing)
+                ? MergeNavigations(existing, navigations)!
+                : navigations;
+        }
+
+        return merged;
+    }
+}

--- a/src/GraphQL.EntityFramework/SelectProjection/NavigationProjectionInfo.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/NavigationProjectionInfo.cs
@@ -1,4 +1,11 @@
 ﻿record NavigationProjectionInfo(
     Type EntityType,
     bool IsCollection,
-    FieldProjectionInfo Projection);
+    FieldProjectionInfo Projection)
+{
+    public NavigationProjectionInfo Merge(NavigationProjectionInfo other) =>
+        this with
+        {
+            Projection = Projection.Merge(other.Projection)
+        };
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Aliased_navigation_selections_merge.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Aliased_navigation_selections_merge.verified.txt
@@ -1,0 +1,32 @@
+﻿{
+  target: {
+    Data: {
+      employees: [
+        {
+          name: Alice,
+          a: {
+            name: Engineering
+          },
+          b: {
+            isActive: true
+          }
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   cast (0 as bit),
+         d.Id,
+         d.IsActive,
+         d.Name,
+         e.DepartmentId,
+         e.Id,
+         e.Name
+from     Employees as e
+         inner join
+         Departments as d
+         on e.DepartmentId = d.Id
+order by e.Name
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Aliased_navigation_selections_merge_nested_navigations.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Aliased_navigation_selections_merge_nested_navigations.verified.txt
@@ -1,0 +1,50 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1,
+          a: [
+            {
+              property: Value2
+            }
+          ],
+          b: [
+            {
+              parentAlias: {
+                property: Value1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         s.Id,
+         s.c,
+         s.Id0,
+         s.Property,
+         s.ParentId,
+         s.Property0,
+         p.Property
+from     ParentEntities as p
+         left outer join
+         (select c.Id,
+                 case when p0.Id is null then cast (1 as bit) else cast (0 as bit) end as c,
+                 p0.Id as Id0,
+                 p0.Property,
+                 c.ParentId,
+                 c.Property as Property0
+          from   ChildEntities as c
+                 left outer join
+                 ParentEntities as p0
+                 on c.ParentId = p0.Id) as s
+         on p.Id = s.ParentId
+order by p.Property,
+         p.Id,
+         s.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Derived_navigation_inline_fragment_inside_fragment_spread.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Derived_navigation_inline_fragment_inside_fragment_spread.verified.txt
@@ -1,0 +1,32 @@
+﻿{
+  target: {
+    Data: {
+      tphDerivedNavEntities: [
+        {
+          property: CategoryItem1,
+          category: {
+            name: Science
+          }
+        },
+        {
+          property: RegionItem1
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   t.Id,
+         t.Discriminator,
+         t.Property,
+         t.CategoryId,
+         t.RegionId,
+         c.Id,
+         c.Name
+from     TphDerivedNavBaseEntities as t
+         left outer join
+         CategoryEntities as c
+         on t.CategoryId = c.Id
+order by t.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Fragment_spread_inside_fragment_spread.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Fragment_spread_inside_fragment_spread.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1,
+          children: [
+            {
+              property: Value2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         c.Id,
+         c.ParentId,
+         c.Property,
+         p.Property
+from     ParentEntities as p
+         left outer join
+         ChildEntities as c
+         on p.Id = c.ParentId
+order by p.Property,
+         p.Id,
+         c.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Fragment_spread_inside_inline_fragment.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Fragment_spread_inside_inline_fragment.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1,
+          children: [
+            {
+              property: Value2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         c.Id,
+         c.ParentId,
+         c.Property,
+         p.Property
+from     ParentEntities as p
+         left outer join
+         ChildEntities as c
+         on p.Id = c.ParentId
+order by p.Property,
+         p.Id,
+         c.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_projects_scalars.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_projects_scalars.verified.txt
@@ -1,0 +1,51 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1,
+          childrenConnection: {
+            totalCount: 2,
+            items: [
+              {
+                property: Value2
+              },
+              {
+                property: Value3
+              }
+            ],
+            edges: [
+              {
+                cursor: 0,
+                node: {
+                  property: Value2
+                }
+              },
+              {
+                cursor: 1,
+                node: {
+                  property: Value3
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         c.Id,
+         c.ParentId,
+         c.Property,
+         p.Property
+from     ParentEntities as p
+         left outer join
+         ChildEntities as c
+         on p.Id = c.ParentId
+order by p.Property,
+         p.Id,
+         c.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
@@ -1,0 +1,50 @@
+﻿{
+  target: {
+    Data: {
+      parentEntitiesConnection: {
+        items: [
+          {
+            property: Value1,
+            childrenConnection: {
+              items: [
+                {
+                  property: Value2
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  sql: [
+    {
+      Text:
+select COUNT(*)
+from   ParentEntities as p
+    },
+    {
+      Text:
+select   p0.Id,
+         c.Id,
+         c.ParentId,
+         c.Property,
+         p0.Property
+from     (select   p.Id,
+                   p.Property
+          from     ParentEntities as p
+          order by p.Property
+          offset @p rows fetch next @p1 rows only) as p0
+         left outer join
+         ChildEntities as c
+         on p0.Id = c.ParentId
+order by p0.Property,
+         p0.Id,
+         c.Id,
+      Parameters: {
+        @p: 0,
+        @p1: 10
+      }
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_projection_based_navigation_field.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_projection_based_navigation_field.verified.txt
@@ -1,0 +1,46 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1,
+          children: [
+            {
+              property: Value2,
+              parentAlias: {
+                property: Value1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         s.Id,
+         s.c,
+         s.Id0,
+         s.Property,
+         s.ParentId,
+         s.Property0,
+         p.Property
+from     ParentEntities as p
+         left outer join
+         (select c.Id,
+                 case when p0.Id is null then cast (1 as bit) else cast (0 as bit) end as c,
+                 p0.Id as Id0,
+                 p0.Property,
+                 c.ParentId,
+                 c.Property as Property0
+          from   ChildEntities as c
+                 left outer join
+                 ParentEntities as p0
+                 on c.ParentId = p0.Id) as s
+         on p.Id = s.ParentId
+order by p.Property,
+         p.Id,
+         s.Id
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_projection_based_scalar_fields.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_projection_based_scalar_fields.verified.txt
@@ -3,9 +3,15 @@
     Data: {
       fieldBuilderProjectionParents: [
         {
-          name: Parent,
+          name: TheParent,
           children: {
-            edges: []
+            items: [
+              {
+                name: TheChild,
+                statusDisplay: Pending Activation,
+                statusViaWithProjection: Pending via WithProjection
+              }
+            ]
           }
         }
       ]

--- a/src/Tests/IntegrationTests/IntegrationTests.Projection_based_field_merges_with_navigation_field.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Projection_based_field_merges_with_navigation_field.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  target: {
+    Data: {
+      childEntities: [
+        {
+          property: Value2,
+          parent: {
+            id: Guid_1
+          },
+          parentAlias: {
+            property: Value1
+          }
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   c.Id,
+         case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
+         p.Id,
+         p.Property,
+         c.ParentId,
+         c.Property
+from     ChildEntities as c
+         left outer join
+         ParentEntities as p
+         on c.ParentId = p.Id
+order by c.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_navigation_merge.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_navigation_merge.cs
@@ -1,0 +1,120 @@
+public partial class IntegrationTests
+{
+    // The same navigation selected under two aliases. Whichever selection was processed first
+    // used to win, so the fields asked for by the other came back as defaults.
+    [Fact]
+    public async Task Aliased_navigation_selections_merge()
+    {
+        var query =
+            """
+            {
+              employees
+              {
+                name
+                a: department
+                {
+                  name
+                }
+                b: department
+                {
+                  isActive
+                }
+              }
+            }
+            """;
+
+        var department = new DepartmentEntity
+        {
+            Name = "Engineering",
+            IsActive = true
+        };
+        var employee = new EmployeeEntity
+        {
+            Name = "Alice",
+            Department = department
+        };
+        department.Employees.Add(employee);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [department, employee]);
+    }
+
+    // A navigation field and a projection based field that projects the same navigation, selected
+    // side by side. The navigation field was processed first, and the projection based field was
+    // then skipped, so the fields it selected were never projected.
+    [Fact]
+    public async Task Projection_based_field_merges_with_navigation_field()
+    {
+        var query =
+            """
+            {
+              childEntities
+              {
+                property
+                parent
+                {
+                  id
+                }
+                parentAlias
+                {
+                  property
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+
+    // Navigations below the aliased selections are merged as well
+    [Fact]
+    public async Task Aliased_navigation_selections_merge_nested_navigations()
+    {
+        var query =
+            """
+            {
+              parentEntities
+              {
+                property
+                a: children
+                {
+                  property
+                }
+                b: children
+                {
+                  parentAlias
+                  {
+                    property
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_nested_fragments.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_nested_fragments.cs
@@ -1,0 +1,132 @@
+public partial class IntegrationTests
+{
+    // Below the root, fragments were followed one level down only, so a fragment that spread
+    // another fragment contributed nothing to the projection.
+    [Fact]
+    public async Task Fragment_spread_inside_fragment_spread()
+    {
+        var query =
+            """
+            {
+              parentEntities
+              {
+                property
+                children
+                {
+                  ...childFields
+                }
+              }
+            }
+
+            fragment childFields on Child
+            {
+              ...childProperty
+            }
+
+            fragment childProperty on Child
+            {
+              property
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+
+    [Fact]
+    public async Task Fragment_spread_inside_inline_fragment()
+    {
+        var query =
+            """
+            {
+              parentEntities
+              {
+                property
+                children
+                {
+                  ... on Child
+                  {
+                    ...childProperty
+                  }
+                }
+              }
+            }
+
+            fragment childProperty on Child
+            {
+              property
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+
+    // The root is abstract, so this takes the include path. The navigation on the derived type is
+    // selected by an inline fragment that sits inside a fragment spread, which was not followed.
+    [Fact]
+    public async Task Derived_navigation_inline_fragment_inside_fragment_spread()
+    {
+        var category = new CategoryEntity
+        {
+            Name = "Science"
+        };
+        var categoryItem = new TphDerivedNavCategoryEntity
+        {
+            Property = "CategoryItem1",
+            Category = category,
+            CategoryId = category.Id
+        };
+        var regionItem = new TphDerivedNavRegionEntity
+        {
+            Property = "RegionItem1"
+        };
+
+        var query =
+            """
+            {
+              tphDerivedNavEntities
+              {
+                ...baseFields
+              }
+            }
+
+            fragment baseFields on TphDerivedNavBaseEntity
+            {
+              property
+              ... on TphDerivedNavCategory
+              {
+                category
+                {
+                  name
+                }
+              }
+            }
+            """;
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [category, categoryItem, regionItem]);
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_nested_projection.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_nested_projection.cs
@@ -1,0 +1,173 @@
+public partial class IntegrationTests
+{
+    // Below the root, the edges/items/node wrappers of a connection were recorded as scalar fields
+    // named after the wrapper, so only the keys of the nodes were projected and every other
+    // scalar came back null.
+    [Fact]
+    public async Task Nested_connection_projects_scalars()
+    {
+        var query =
+            """
+            {
+              parentEntities
+              {
+                property
+                childrenConnection(first: 10)
+                {
+                  totalCount
+                  items
+                  {
+                    property
+                  }
+                  edges
+                  {
+                    cursor
+                    node
+                    {
+                      property
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        // Fixed ids, since the nested collection is ordered by key
+        var child1 = new ChildEntity
+        {
+            Id = new("00000000-0000-0000-0000-000000000001"),
+            Property = "Value2",
+            Parent = parent
+        };
+        var child2 = new ChildEntity
+        {
+            Id = new("00000000-0000-0000-0000-000000000002"),
+            Property = "Value3",
+            Parent = parent
+        };
+        parent.Children.Add(child1);
+        parent.Children.Add(child2);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child1, child2]);
+    }
+
+    [Fact]
+    public async Task Nested_connection_under_root_connection_projects_scalars()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first: 10)
+              {
+                items
+                {
+                  property
+                  childrenConnection(first: 10)
+                  {
+                    items
+                    {
+                      property
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+
+    // Projection metadata was only looked up for the root sub fields. A projection based field
+    // below a navigation was matched against the entity by its GraphQL name, found nothing, and
+    // so the navigation it projects was never loaded.
+    [Fact]
+    public async Task Nested_projection_based_navigation_field()
+    {
+        var query =
+            """
+            {
+              parentEntities
+              {
+                property
+                children
+                {
+                  property
+                  parentAlias
+                  {
+                    property
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value2",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+
+    [Fact]
+    public async Task Nested_projection_based_scalar_fields()
+    {
+        var query =
+            """
+            {
+              fieldBuilderProjectionParents
+              {
+                name
+                children(first: 10)
+                {
+                  items
+                  {
+                    name
+                    statusDisplay
+                    statusViaWithProjection
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new FieldBuilderProjectionParentEntity
+        {
+            Name = "TheParent"
+        };
+        var child = new FieldBuilderProjectionEntity
+        {
+            Name = "TheChild",
+            Status = EntityStatus.Pending,
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child]);
+    }
+}


### PR DESCRIPTION


Projection metadata and connection wrappers were only handled for the root sub fields. Nested selection sets are now processed with the graph type they select from, so a projection based field or a connection below a navigation is projected the same as at the root.

Selections of the same navigation are merged rather than the first or last one winning, and fragments are followed at any depth.