### PR TITLE
Match filters on the runtime type of each item

### DIFF
--- a/src/GraphQL.EntityFramework/Filters/Filters.cs
+++ b/src/GraphQL.EntityFramework/Filters/Filters.cs
@@ -92,33 +92,34 @@ public class Filters<TDbContext>
         }
 
         forType.Add(entry);
+        filtersByType.Clear();
     }
 
     /// <summary>
-    /// Get all filters that apply to the specified entity type (including base type filters).
+    /// Filters are matched against the runtime type of each item rather than the type of the field
+    /// that returned it, so a filter on a derived type applies to derived instances in a base typed
+    /// list, and a field typed as object is filtered the same as a typed one. Looked up per item,
+    /// so the result is cached per type; the cache is reset when a filter is added.
     /// </summary>
-    internal IEnumerable<IFilterEntry<TDbContext>> GetFilters<TEntity>()
-        where TEntity : class
-    {
-        var type = typeof(TEntity);
-        return entries
-            .Where(_ => _.Key.IsAssignableFrom(type))
-            .SelectMany(_ => _.Value);
-    }
+    ConcurrentDictionary<Type, List<IFilterEntry<TDbContext>>> filtersByType = new();
+
+    List<IFilterEntry<TDbContext>> GetFilters(Type entityType) =>
+        filtersByType.GetOrAdd(
+            entityType,
+            type => entries
+                .Where(_ => _.Key.IsAssignableFrom(type))
+                .SelectMany(_ => _.Value)
+                .ToList());
 
     /// <summary>
-    /// Get all filters that apply to the specified entity type (including base type filters).
+    /// The filters whose projection requirements a query for <paramref name="entityType"/> has to
+    /// load: those on the type and its base types, which apply to every item, and those on derived
+    /// types, which apply to the derived items the query can return.
     /// </summary>
-    internal IEnumerable<IFilterEntry<TDbContext>> GetFilters(Type entityType) =>
+    internal IEnumerable<IFilterEntry<TDbContext>> GetFiltersForHierarchy(Type entityType) =>
         entries
-            .Where(_ => _.Key.IsAssignableFrom(entityType))
+            .Where(_ => _.Key.IsAssignableFrom(entityType) || entityType.IsAssignableFrom(_.Key))
             .SelectMany(_ => _.Value);
-
-    /// <summary>
-    /// Get all registered filter entries.
-    /// </summary>
-    internal IEnumerable<IFilterEntry<TDbContext>> GetAllFilters() =>
-        entries.Values.SelectMany(_ => _);
 
     /// <summary>
     /// Returns true if there are any filters registered.
@@ -137,16 +138,10 @@ public class Filters<TDbContext>
             return result;
         }
 
-        var filterEntries = GetFilters<TEntity>().ToList();
-        if (filterEntries.Count == 0)
-        {
-            return result;
-        }
-
         var list = new List<TEntity>();
         foreach (var item in result)
         {
-            if (await ShouldIncludeItem(userContext, data, userPrincipal, item, filterEntries))
+            if (await ShouldIncludeItem(userContext, data, userPrincipal, item))
             {
                 list.Add(item);
             }
@@ -155,15 +150,13 @@ public class Filters<TDbContext>
         return list;
     }
 
-    static async Task<bool> ShouldIncludeItem<TEntity>(
+    async Task<bool> ShouldIncludeItem(
         object userContext,
         TDbContext data,
         ClaimsPrincipal? userPrincipal,
-        TEntity item,
-        List<IFilterEntry<TDbContext>> filterEntries)
-        where TEntity : class
+        object item)
     {
-        foreach (var entry in filterEntries)
+        foreach (var entry in GetFilters(item.GetType()))
         {
             if (!await entry.ShouldIncludeWithProjection(userContext, data, userPrincipal, item))
             {
@@ -174,29 +167,30 @@ public class Filters<TDbContext>
         return true;
     }
 
-    internal virtual async Task<bool> ShouldInclude<TEntity>(
+    internal virtual Task<bool> ShouldInclude<TEntity>(
         object userContext,
         TDbContext data,
         ClaimsPrincipal? userPrincipal,
         TEntity? item)
-        where TEntity : class
+        where TEntity : class =>
+        ShouldInclude(userContext, data, userPrincipal, (object?)item);
+
+    internal Task<bool> ShouldInclude(
+        object userContext,
+        TDbContext data,
+        ClaimsPrincipal? userPrincipal,
+        object? item)
     {
         if (item is null)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         if (entries.Count == 0)
         {
-            return true;
+            return Task.FromResult(true);
         }
 
-        var filterEntries = GetFilters<TEntity>().ToList();
-        if (filterEntries.Count == 0)
-        {
-            return true;
-        }
-
-        return await ShouldIncludeItem(userContext, data, userPrincipal, item, filterEntries);
+        return ShouldIncludeItem(userContext, data, userPrincipal, item);
     }
 }

--- a/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
@@ -280,15 +280,13 @@ public static class FieldBuilderExtensions
             return result;
         }
 
-        // For reference types, apply filters if available
-        if (filters != null && result is not null)
+        // For reference types, apply filters if available. Matched on the runtime type of the
+        // result, so a field typed as object is filtered the same as a typed one.
+        if (filters != null &&
+            result is not null &&
+            !await filters.ShouldInclude(context.UserContext, dbContext, context.User, (object)result))
         {
-            // Use dynamic to work around the class constraint on ShouldInclude
-            dynamic dynamicFilters = filters;
-            if (!await dynamicFilters.ShouldInclude(context.UserContext, dbContext, context.User, result))
-            {
-                return default!;
-            }
+            return default!;
         }
 
         return result;

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -198,7 +198,7 @@
     {
         navigations.TryGetValue(entityType, out var navigationProperties);
 
-        foreach (var filter in filters.GetFilters(entityType))
+        foreach (var filter in filters.GetFiltersForHierarchy(entityType))
         {
             projection = filter.AddRequirements(projection, navigationProperties);
         }

--- a/src/Tests/IntegrationTests/Graphs/ChildGraphType.cs
+++ b/src/Tests/IntegrationTests/Graphs/ChildGraphType.cs
@@ -9,6 +9,12 @@
             projection: _ => _.Parent,
             resolve: _ => _.Projection,
             graphType: typeof(ParentGraphType));
+        // Field<TGraphType> builds an object typed builder, so the filter applied has to be
+        // chosen by the runtime type of the result
+        Field<ParentGraphType>("parentObject")
+            .Resolve(
+                projection: _ => _.Parent,
+                resolve: _ => _.Projection!);
         AutoMap();
     }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_applies_to_object_typed_projection_field.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_applies_to_object_typed_projection_field.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  target: {
+    Data: {
+      childEntities: [
+        {
+          property: Value1,
+          parentAlias: null,
+          parentObject: null
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   c.Id,
+         case when p.Id is null then cast (1 as bit) else cast (0 as bit) end,
+         p.Id,
+         p.Property,
+         c.ParentId,
+         c.Property
+from     ChildEntities as c
+         left outer join
+         ParentEntities as p
+         on c.ParentId = p.Id
+order by c.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_applies_to_base_typed_list.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_applies_to_base_typed_list.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  target: {
+    Data: {
+      baseEntities: [
+        {
+          property: Value1
+        },
+        {
+          property: Value2
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   b.Id,
+         b.Discriminator,
+         b.Property,
+         b.Status
+from     BaseEntities as b
+order by b.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_applies_to_base_typed_single.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_applies_to_base_typed_single.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  target: {
+    Type: SingleEntityNotFoundException,
+    Message: Not found
+  },
+  sql: {
+    Text:
+select top (2) t.Id,
+               t.Discriminator,
+               t.Property,
+               t.LeafProperty
+from   TphRootEntities as t
+where  t.Id = @p1,
+    Parameters: {
+      @p1: Guid_1
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_requirements_loaded_by_base_typed_query.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_requirements_loaded_by_base_typed_query.verified.txt
@@ -1,0 +1,34 @@
+﻿{
+  target: {
+    Data: {
+      interfaceGraphConnection: {
+        items: [
+          {
+            property: Value2
+          }
+        ]
+      }
+    }
+  },
+  sql: [
+    {
+      Text:
+select COUNT(*)
+from   BaseEntities as b
+    },
+    {
+      Text:
+select   b.Id,
+         b.Discriminator,
+         b.Property,
+         b.Status
+from     BaseEntities as b
+order by b.Property
+offset @p rows fetch next @p1 rows only,
+      Parameters: {
+        @p: 0,
+        @p1: 10
+      }
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
@@ -364,6 +364,7 @@ type ChildEdge {
 
 type Child {
   parentAlias: Parent
+  parentObject: Parent
   parent: Parent
   id: ID!
   nullable: Int

--- a/src/Tests/IntegrationTests/IntegrationTests_filter_runtime_type.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_filter_runtime_type.cs
@@ -1,0 +1,153 @@
+public partial class IntegrationTests
+{
+    // Field<TGraphType> returns an object typed builder. The filter lookup used the static type,
+    // so no filter matched object and a denied parent was returned through parentObject while the
+    // typed parentAlias next to it was correctly null.
+    [Fact]
+    public async Task Filter_applies_to_object_typed_projection_field()
+    {
+        var query =
+            """
+            {
+              childEntities
+              {
+                property
+                parentAlias
+                {
+                  property
+                }
+                parentObject
+                {
+                  property
+                }
+              }
+            }
+            """;
+
+        var parent = new ParentEntity
+        {
+            Property = "Ignore"
+        };
+        var child = new ChildEntity
+        {
+            Property = "Value1",
+            Parent = parent
+        };
+        parent.Children.Add(child);
+
+        var filters = new Filters<IntegrationDbContext>();
+        filters.For<ParentEntity>().Add(
+            projection: _ => _.Property,
+            filter: (_, _, _, property) => property != "Ignore");
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, filters, [parent, child]);
+    }
+
+    // A filter registered for a derived type was only applied to fields typed as that derived
+    // type. Derived instances returned by a base typed field went unfiltered.
+    [Fact]
+    public async Task Filter_on_derived_type_applies_to_base_typed_list()
+    {
+        var query =
+            """
+            {
+              baseEntities
+              {
+                property
+              }
+            }
+            """;
+
+        var derived = new DerivedEntity
+        {
+            Property = "Ignore"
+        };
+        var derivedKept = new DerivedEntity
+        {
+            Property = "Value1"
+        };
+        var derivedWithNavigation = new DerivedWithNavigationEntity
+        {
+            Property = "Value2"
+        };
+
+        var filters = new Filters<IntegrationDbContext>();
+        filters.For<DerivedEntity>().Add(
+            projection: _ => _.Property,
+            filter: (_, _, _, property) => property != "Ignore");
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, filters, [derived, derivedKept, derivedWithNavigation]);
+    }
+
+    // The single field variant, so the runtime type is used for a lone item as well as a list
+    [Fact]
+    public async Task Filter_on_derived_type_applies_to_base_typed_single()
+    {
+        var leaf = new TphLeafEntity
+        {
+            Property = "Ignore",
+            LeafProperty = "Leaf"
+        };
+
+        var query =
+            $$"""
+            {
+              tphMiddleEntity(id: "{{leaf.Id}}")
+              {
+                property
+              }
+            }
+            """;
+
+        var filters = new Filters<IntegrationDbContext>();
+        filters.For<TphLeafEntity>().Add(
+            projection: _ => _.Property,
+            filter: (_, _, _, property) => property != "Ignore");
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, filters, [leaf]);
+    }
+
+    // The projection requirements of a derived type filter are loaded by a base typed query, so
+    // the filter can read them from the derived items it is applied to.
+    [Fact]
+    public async Task Filter_on_derived_type_requirements_loaded_by_base_typed_query()
+    {
+        var query =
+            """
+            {
+              interfaceGraphConnection(first: 10)
+              {
+                items
+                {
+                  property
+                }
+              }
+            }
+            """;
+
+        var derived = new DerivedEntity
+        {
+            Property = "Value1",
+            Status = "Hidden"
+        };
+        var derivedKept = new DerivedEntity
+        {
+            Property = "Value2",
+            Status = "Visible"
+        };
+
+        var filters = new Filters<IntegrationDbContext>();
+        filters.For<DerivedEntity>().Add(
+            projection: _ => _.Status,
+            filter: (_, _, _, status) => status != "Hidden");
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, filters, [derived, derivedKept]);
+    }
+
+    static Task RunQuery(SqlDatabase<IntegrationDbContext> database, string query, Filters<IntegrationDbContext> filters, object[] entities, [CallerFilePath] string sourceFile = "") =>
+        RunQuery(database, query, null, filters, false, entities, sourceFile: sourceFile);
+}


### PR DESCRIPTION
Filters were looked up by the type argument of the field that returned an item. A field typed as object matched no filter at all, and a filter on a derived type was not applied to derived instances returned by a base typed field. Filters are now matched on the runtime type of each item, cached per type, and the projection requirements of filters on derived types are loaded by base typed queries.

The dynamic dispatch in the projection based field resolvers is gone with it.