### PR TITLE
Fix self referencing list where paths, the in memory ids key name, and in on other types

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -23,6 +23,7 @@ partial class EfGraphQLService<TDbContext>
         var compiledProjection = projection.Compile();
 
         var hasId = keyNames.ContainsKey(typeof(TReturn));
+        var names = GetKeyNames<TReturn>();
         builder.ResolveAsync(async context =>
         {
             var efFieldContext = BuildContext(context);
@@ -58,7 +59,7 @@ partial class EfGraphQLService<TDbContext>
                 throw new("This API expects the resolver to return a IEnumerable, not an IQueryable. Instead use AddQueryConnectionField.");
             }
 
-            enumerable = enumerable.ApplyGraphQlArguments(hasId, context, omitQueryArguments);
+            enumerable = enumerable.ApplyGraphQlArguments(names, context, omitQueryArguments);
             if (efFieldContext.Filters != null)
             {
                 enumerable = await efFieldContext.Filters.ApplyFilter(enumerable, context.UserContext, efFieldContext.DbContext, context.User);

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
@@ -15,6 +15,7 @@ partial class EfGraphQLService<TDbContext>
         Ensure.NotWhiteSpace(nameof(name), name);
 
         var hasId = keyNames.ContainsKey(typeof(TReturn));
+        var names = GetKeyNames<TReturn>();
         var field = new FieldType
         {
             Name = name,
@@ -47,7 +48,7 @@ partial class EfGraphQLService<TDbContext>
                 throw new("This API expects the resolver to return a IEnumerable, not an IQueryable. Instead use AddQueryField.");
             }
 
-            result = result.ApplyGraphQlArguments(hasId, context, omitQueryArguments);
+            result = result.ApplyGraphQlArguments(names, context, omitQueryArguments);
             if (fieldContext.Filters == null)
             {
                 return result;

--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
@@ -6,6 +6,17 @@ public static partial class ArgumentProcessor
         this IEnumerable<TItem> items,
         bool hasId,
         IResolveFieldContext context,
+        bool omitQueryArguments) =>
+        items.ApplyGraphQlArguments(hasId ? ["Id"] : null, context, omitQueryArguments);
+
+    /// <summary>
+    /// The key name comes from the model, the same as on the queryable path. The overload above
+    /// assumed the key is named Id, so an entity keyed by anything else failed on the ids argument.
+    /// </summary>
+    public static IEnumerable<TItem> ApplyGraphQlArguments<TItem>(
+        this IEnumerable<TItem> items,
+        List<string>? keyNames,
+        IResolveFieldContext context,
         bool omitQueryArguments)
     {
         if (omitQueryArguments)
@@ -15,11 +26,12 @@ public static partial class ArgumentProcessor
 
         var alreadyOrdered = items is ICollection<TItem>;
 
-        if (hasId)
+        if (keyNames is not null)
         {
             if (ArgumentReader.TryReadIds(context, out var idValues))
             {
-                var predicate = ExpressionBuilder<TItem>.BuildIdPredicate("Id", idValues);
+                var keyName = GetKeyName(keyNames);
+                var predicate = ExpressionBuilder<TItem>.BuildIdPredicate(keyName, idValues);
                 items = items.Where(Compile(predicate));
             }
         }

--- a/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
@@ -142,21 +142,12 @@ public static partial class ExpressionBuilder<T>
         // Get the list item type details
         var listItemType = property.PropertyType.GetGenericArguments().Single();
 
-        // Generate the predicate for the list item type
-        var genericType = typeof(ExpressionBuilder<>)
-            .MakeGenericType(listItemType);
-        var buildPredicate = genericType
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .SingleOrDefault(_ => _.Name == "BuildPredicate" &&
-                                  _.GetParameters().Length == 4);
-        if (buildPredicate == null)
-        {
-            throw new($"Could not find BuildPredicate method on {genericType.FullName}");
-        }
+        var (buildPredicate, anyMethod) = ListMethods(listItemType);
 
-        var subPredicate = (Expression)buildPredicate
+        // Generate the predicate for the list item type
+        var subPredicate = (LambdaExpression)buildPredicate
             .Invoke(
-                new(),
+                null,
                 [
                     listPath,
                     comparison,
@@ -164,15 +155,53 @@ public static partial class ExpressionBuilder<T>
                     false
                 ])!;
 
-        // Generate a method info for the Any Enumerable Static Method
-        var anyInfo = typeof(Enumerable)
-            .GetMethods(BindingFlags.Static | BindingFlags.Public)
-            .First(_ => _.Name == "Any" &&
-                        _.GetParameters().Length == 2)
-            .MakeGenericMethod(listItemType);
+        // The sub predicate is built on the parameter PropertyCache shares for the item type. When
+        // the list holds the enclosing type, that is the same instance as the outer parameter, and
+        // EF's parameter replacement then rewrites the inner lambda as well. Rebind the inner lambda
+        // to its own parameter.
+        var itemParameter = Expression.Parameter(listItemType, "item");
+        var body = new ParameterReplacer(subPredicate.Parameters[0], itemParameter).Visit(subPredicate.Body);
+        var itemPredicate = Expression.Lambda(body, itemParameter);
 
         // Create Any Expression Call
-        return Expression.Call(anyInfo, property.Left, subPredicate);
+        return Expression.Call(anyMethod, property.Left, itemPredicate);
+    }
+
+    static ConcurrentDictionary<Type, (MethodInfo BuildPredicate, MethodInfo Any)> listMethods = new();
+
+    /// <summary>
+    /// Both lookups were being repeated per where clause with a list path. The item types are
+    /// bounded by the model, so they are safe to hold on to.
+    /// </summary>
+    static (MethodInfo BuildPredicate, MethodInfo Any) ListMethods(Type listItemType) =>
+        listMethods.GetOrAdd(
+            listItemType,
+            type =>
+            {
+                var genericType = typeof(ExpressionBuilder<>).MakeGenericType(type);
+                var buildPredicate = genericType
+                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .SingleOrDefault(_ => _.Name == nameof(BuildPredicate) &&
+                                          _.GetParameters().Length == 4);
+                if (buildPredicate == null)
+                {
+                    throw new($"Could not find BuildPredicate method on {genericType.FullName}");
+                }
+
+                var any = typeof(Enumerable)
+                    .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                    .First(_ => _.Name == nameof(Enumerable.Any) &&
+                                _.GetParameters().Length == 2)
+                    .MakeGenericMethod(type);
+
+                return (buildPredicate, any);
+            });
+
+    class ParameterReplacer(ParameterExpression original, ParameterExpression replacement) :
+        ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == original ? replacement : node;
     }
 
     static Expression GetExpression(string path, Comparison comparison, string?[]? values)

--- a/src/GraphQL.EntityFramework/Where/ReflectionCache.cs
+++ b/src/GraphQL.EntityFramework/Where/ReflectionCache.cs
@@ -27,31 +27,12 @@
         typeof(string)
             .GetMethod("EndsWith", [typeof(string)])!;
 
-    static FrozenDictionary<Type, MethodInfo> listContainsCache;
+    static ConcurrentDictionary<Type, MethodInfo> listContainsCache = new();
 
-    static ReflectionCache() =>
-        listContainsCache = FrozenDictionary.Create(
-            new KeyValuePair<Type, MethodInfo>(typeof(Guid), GetContains<Guid>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(Guid?), GetContains<Guid?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(bool), GetContains<bool>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(bool?), GetContains<bool?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(int), GetContains<int>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(int?), GetContains<int?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(short), GetContains<short>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(short?), GetContains<short?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(long), GetContains<long>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(long?), GetContains<long?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(uint), GetContains<uint>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(uint?), GetContains<uint?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(ushort), GetContains<ushort>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(ushort?), GetContains<ushort?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(ulong), GetContains<ulong>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(ulong?), GetContains<ulong?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(DateTime), GetContains<DateTime>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(DateTime?), GetContains<DateTime?>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(DateTimeOffset), GetContains<DateTimeOffset>()),
-            new KeyValuePair<Type, MethodInfo>(typeof(DateTimeOffset?), GetContains<DateTimeOffset?>()));
-
+    /// <summary>
+    /// Contains on a list of the property type. Was a fixed set of types, which left `in` failing
+    /// for any other type the list conversion could handle. Strings take a different route.
+    /// </summary>
     public static MethodInfo? GetListContains(Type type)
     {
         if (type == typeof(string))
@@ -59,22 +40,10 @@
             return null;
         }
 
-        // Try FrozenDictionary lookup first - O(1) for common types
-        if (listContainsCache.TryGetValue(type, out var method))
-        {
-            return method;
-        }
-
-        if (type.IsEnumType())
-        {
-            return typeof(ICollection<>).MakeGenericType(type).GetMethod("Contains");
-        }
-
-        return null;
+        return listContainsCache.GetOrAdd(
+            type,
+            _ => typeof(ICollection<>).MakeGenericType(_).GetMethod("Contains")!);
     }
-
-    static MethodInfo GetContains<T>() =>
-        typeof(ICollection<T>).GetMethod("Contains")!;
 
     public static bool TryGetEnumType(this Type type, [NotNullWhen(true)] out Type? enumType)
     {

--- a/src/GraphQL.EntityFramework/Where/TypeConverter.cs
+++ b/src/GraphQL.EntityFramework/Where/TypeConverter.cs
@@ -98,7 +98,15 @@
             return (IList)getList.Invoke(null, [values])!;
         }
 
-        throw new($"Could not convert strings to {type.FullName}.");
+        // Anything else the single value conversion handles, such as decimal or double, is
+        // converted item by item into a list of the property type
+        var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(type))!;
+        foreach (var value in values)
+        {
+            list.Add(ConvertStringToType(value, type));
+        }
+
+        return list;
     }
 
     static MethodInfo enumListMethod = typeof(TypeConverter)

--- a/src/Tests/ArgumentProcessorTests.cs
+++ b/src/Tests/ArgumentProcessorTests.cs
@@ -1,0 +1,71 @@
+using GraphQL.Execution;
+
+public class ArgumentProcessorTests
+{
+    // The in memory path assumed the key is named Id, so an entity keyed by anything else failed
+    // on the ids argument, while the queryable path resolved the key from the model.
+    [Fact]
+    public void Ids_use_key_name_from_model()
+    {
+        var entity1 = new NamedIdEntity
+        {
+            Property = "one"
+        };
+        var entity2 = new NamedIdEntity
+        {
+            Property = "two"
+        };
+        var context = BuildContext(entity1.NamedId);
+
+        var result = new List<NamedIdEntity>
+            {
+                entity1,
+                entity2
+            }
+            .ApplyGraphQlArguments(["NamedId"], context, false)
+            .ToList();
+
+        Assert.Equal(["one"], result.Select(_ => _.Property));
+    }
+
+    [Fact]
+    public void Ids_default_to_Id_for_the_hasId_overload()
+    {
+        var entity1 = new ParentEntity
+        {
+            Property = "one"
+        };
+        var entity2 = new ParentEntity
+        {
+            Property = "two"
+        };
+        var context = BuildContext(entity2.Id);
+
+        var result = new List<ParentEntity>
+            {
+                entity1,
+                entity2
+            }
+            .ApplyGraphQlArguments(true, context, false)
+            .ToList();
+
+        Assert.Equal(["two"], result.Select(_ => _.Property));
+    }
+
+    static ResolveFieldContext BuildContext(Guid id) =>
+        new()
+        {
+            Arguments = new Dictionary<string, ArgumentValue>
+            {
+                ["ids"] = new(new object[]
+                {
+                    id.ToString()
+                }, ArgumentSource.Literal)
+            },
+            FieldDefinition = new()
+            {
+                Name = "entities"
+            },
+            Errors = []
+        };
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_date.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_date.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  target: {
+    Data: {
+      dateEntities: [
+        {
+          property: 2020-01-01
+        },
+        {
+          property: 2020-01-03
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   d.Id,
+         d.Property
+from     DateEntities as d
+where    d.Property in (@p1,
+                        @p2)
+order by d.Property,
+    Parameters: {
+      @p1: Date_1,
+      @p2: Date_2
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_decimal.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_decimal.verified.txt
@@ -1,0 +1,38 @@
+﻿{
+  target: {
+    Data: {
+      fieldBuilderProjectionEntities: [
+        {
+          name: One,
+          salary: 10.50
+        },
+        {
+          name: Three,
+          salary: 30.00
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   f.Id,
+         f.Name,
+         f.Salary
+from     FieldBuilderProjectionEntities as f
+where    f.Salary in (@p1,
+                      @p2)
+order by f.Name,
+    Parameters: {
+      @p1: {
+        Value: 10.5,
+        Precision: 18,
+        Scale: 2
+      },
+      @p2: {
+        Value: 30.0,
+        Precision: 18,
+        Scale: 2
+      }
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_time.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Where_in_on_time.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  target: {
+    Data: {
+      timeEntities: [
+        {
+          property: 10:00:00
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select t.Id,
+       t.Property
+from   TimeEntities as t
+where  t.Property = @p1,
+    Parameters: {
+      @p1: Time_1
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_in_comparison.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_in_comparison.cs
@@ -1,0 +1,95 @@
+public partial class IntegrationTests
+{
+    // The `in` comparison was limited to a fixed set of types for the list Contains lookup, which
+    // did not include Date and Time even though their values could be converted.
+    [Fact]
+    public async Task Where_in_on_date()
+    {
+        var query =
+            """
+            {
+              dateEntities (where: {path: "Property", comparison: in, value: ["2020-01-01", "2020-01-03"]}, orderBy: {path: "property"})
+              {
+                property
+              }
+            }
+            """;
+
+        var entity1 = new DateEntity
+        {
+            Property = new(2020, 1, 1)
+        };
+        var entity2 = new DateEntity
+        {
+            Property = new(2020, 1, 2)
+        };
+        var entity3 = new DateEntity
+        {
+            Property = new(2020, 1, 3)
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity1, entity2, entity3]);
+    }
+
+    [Fact]
+    public async Task Where_in_on_time()
+    {
+        var query =
+            """
+            {
+              timeEntities (where: {path: "Property", comparison: in, value: ["10:00:00"]})
+              {
+                property
+              }
+            }
+            """;
+
+        var entity1 = new TimeEntity
+        {
+            Property = new(10, 0)
+        };
+        var entity2 = new TimeEntity
+        {
+            Property = new(11, 0)
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity1, entity2]);
+    }
+
+    // decimal had neither a list converter nor a Contains entry
+    [Fact]
+    public async Task Where_in_on_decimal()
+    {
+        var query =
+            """
+            {
+              fieldBuilderProjectionEntities (where: {path: "Salary", comparison: in, value: ["10.5", "30"]})
+              {
+                name
+                salary
+              }
+            }
+            """;
+
+        var entity1 = new FieldBuilderProjectionEntity
+        {
+            Name = "One",
+            Salary = 10.5m
+        };
+        var entity2 = new FieldBuilderProjectionEntity
+        {
+            Name = "Two",
+            Salary = 20
+        };
+        var entity3 = new FieldBuilderProjectionEntity
+        {
+            Name = "Three",
+            Salary = 30
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [entity1, entity2, entity3]);
+    }
+}

--- a/src/Tests/SelfReferencingWhereTests.cs
+++ b/src/Tests/SelfReferencingWhereTests.cs
@@ -1,0 +1,79 @@
+// A where path into a collection of the enclosing type built the inner lambda on the same
+// parameter instance as the outer one, and EF's parameter replacement then rewrote both.
+public class SelfReferencingWhereTests
+{
+    static SqlInstance<SelfReferencingContext> sqlInstance = new(
+        buildTemplate: async data =>
+        {
+            await data.Database.EnsureCreatedAsync();
+            var root = new Node
+            {
+                Name = "root"
+            };
+            root.Children.Add(new()
+            {
+                Name = "a"
+            });
+            root.Children.Add(new()
+            {
+                Name = "b"
+            });
+            var other = new Node
+            {
+                Name = "other"
+            };
+            other.Children.Add(new()
+            {
+                Name = "c"
+            });
+            data.AddRange(root, other);
+            await data.SaveChangesAsync();
+        },
+        constructInstance: builder => new(builder.Options));
+
+    [Fact]
+    public async Task List_path_into_same_type()
+    {
+        await using var database = await sqlInstance.Build();
+        var predicate = ExpressionBuilder<Node>.BuildPredicate("children[name]", Comparison.Equal, ["a"]);
+        var names = await database.Context.Nodes
+            .Where(predicate)
+            .Select(_ => _.Name)
+            .ToListAsync();
+        Assert.Equal(["root"], names);
+    }
+
+    [Fact]
+    public async Task List_path_into_same_type_negated()
+    {
+        await using var database = await sqlInstance.Build();
+        var predicate = ExpressionBuilder<Node>.BuildPredicate("children[name]", Comparison.Equal, ["a"], negate: true);
+        var names = await database.Context.Nodes
+            .Where(predicate)
+            .OrderBy(_ => _.Name)
+            .Select(_ => _.Name)
+            .ToListAsync();
+        Assert.Equal(["a", "b", "c", "other"], names);
+    }
+
+    public class Node
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string? Name { get; set; }
+        public Guid? ParentId { get; set; }
+        public Node? Parent { get; set; }
+        public List<Node> Children { get; set; } = [];
+    }
+
+    public class SelfReferencingContext(DbContextOptions options) :
+        DbContext(options)
+    {
+        public DbSet<Node> Nodes { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Node>()
+                .HasMany(_ => _.Children)
+                .WithOne(_ => _.Parent)
+                .HasForeignKey(_ => _.ParentId);
+    }
+}


### PR DESCRIPTION


A where path into a collection of the enclosing type built the inner lambda on the same parameter as the outer one, which EF rejected. The inner lambda now gets its own parameter.

The in memory argument path assumed the key is named Id. It now takes the key names from the model, the same as the queryable path.

The in comparison was limited to a fixed set of types. Contains is now built for any list type, and values of other types are converted one by one.