### PR TITLE
Project concrete TPH base types as a chain of type tests

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService.cs
@@ -28,7 +28,29 @@ public partial class EfGraphQLService<TDbContext> :
         var foreignKeys = ForeignKeyExtractor.GetForeignKeyProperties(model);
 
         Navigations = NavigationReader.GetNavigationProperties(model);
-        includeAppender = new(Navigations, keyNames, foreignKeys);
+
+        // A type with derived types is projected as a chain of type tests, most derived first,
+        // so the derived types are listed base most first for wrapping
+        var derivedTypes = model.GetEntityTypes()
+            .Where(_ => _.GetDirectlyDerivedTypes().Any())
+            .ToDictionary(
+                _ => _.ClrType,
+                _ => (IReadOnlyList<Type>)_.GetDerivedTypes()
+                    .OrderBy(derived => Depth(derived.ClrType))
+                    .Select(derived => derived.ClrType)
+                    .ToList());
+        includeAppender = new(Navigations, keyNames, foreignKeys, derivedTypes);
+    }
+
+    static int Depth(Type type)
+    {
+        var depth = 0;
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            depth++;
+        }
+
+        return depth;
     }
 
     public IReadOnlyDictionary<Type, IReadOnlyDictionary<string, Navigation>> Navigations { get; }

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -1,7 +1,8 @@
 ﻿class IncludeAppender(
     IReadOnlyDictionary<Type, IReadOnlyDictionary<string, Navigation>> navigations,
     IReadOnlyDictionary<Type, List<string>> keyNames,
-    IReadOnlyDictionary<Type, IReadOnlySet<string>> foreignKeys)
+    IReadOnlyDictionary<Type, IReadOnlySet<string>> foreignKeys,
+    IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes)
 {
     public bool TryGetProjectionExpressionWithFilters<TDbContext, TItem>(
         IResolveFieldContext context,
@@ -29,7 +30,7 @@
             projection = MergeFilterFieldsIntoProjection(projection, filters, type);
         }
 
-        return SelectExpressionBuilder.TryBuild(projection, keyNames, out expression);
+        return SelectExpressionBuilder.TryBuild(projection, keyNames, derivedTypes, out expression);
     }
 
     public IQueryable<TItem> AddIncludes<TDbContext, TItem>(
@@ -241,7 +242,7 @@
         }
 
         // Scan for derived-type navigations from inline fragments (TPH support)
-        var derivedNavigations = GetDerivedNavigationsFromFragments(context, entityType);
+        var derivedNavigations = GetDerivedNavigationsFromFragments(context, entityType, scalarFields);
 
         return new(scalarFields, keys, foreignKeyNames, navProjections, derivedNavigations);
     }
@@ -318,7 +319,8 @@
     /// </summary>
     Dictionary<Type, Dictionary<string, NavigationProjectionInfo>>? GetDerivedNavigationsFromFragments(
         IResolveFieldContext context,
-        Type entityType)
+        Type entityType,
+        HashSet<string> scalarFields)
     {
         var (selectionSet, leafGraphType) = GetLeafSelection(context);
         if (selectionSet?.Selections is null)
@@ -339,9 +341,14 @@
                 continue;
             }
 
-            if (!navigations.TryGetValue(derivedType, out var derivedNavProps) ||
+            navigations.TryGetValue(derivedType, out var derivedNavProps);
+            if (derivedNavProps is null ||
                 !derivedNavProps.TryGetValue(field.Name.StringValue, out var navigation))
             {
+                // A scalar of the derived type. The root sub fields exclude fields conditional on
+                // another type, so it is recorded here; it resolves against the derived type's
+                // properties when that type's member init is built, and is skipped for the base.
+                scalarFields.Add(field.Name.StringValue);
                 continue;
             }
 

--- a/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace GraphQL.EntityFramework;
+namespace GraphQL.EntityFramework;
 
 static class SelectExpressionBuilder
 {
@@ -19,7 +19,9 @@ static class SelectExpressionBuilder
 
     static ConcurrentDictionary<Type, EntityTypeMetadata> entityMetadataCache = new();
 
-    record PropertyMetadata(Type EntityType, PropertyInfo Property, bool CanWrite, bool IsAutoProperty, MemberExpression PropertyAccess, MemberBinding? Binding)
+    static IReadOnlyDictionary<Type, IReadOnlyList<Type>> noDerivedTypes = new Dictionary<Type, IReadOnlyList<Type>>();
+
+    record PropertyMetadata(Type EntityType, PropertyInfo Property, bool CanWrite, bool IsAutoProperty)
     {
         MethodInfo? cachedOrderBy;
 
@@ -43,236 +45,131 @@ static class SelectExpressionBuilder
         FieldProjectionInfo projection,
         IReadOnlyDictionary<Type, List<string>> keyNames,
         [NotNullWhen(true)] out Expression<Func<TEntity, TEntity>>? expression)
-        where TEntity : class
-    {
-        expression = BuildExpression<TEntity>(projection, keyNames);
-        return expression != null;
-    }
+        where TEntity : class =>
+        TryBuild(projection, keyNames, noDerivedTypes, out expression);
 
-    static Expression<Func<TEntity, TEntity>>? BuildExpression<TEntity>(
+    /// <param name="derivedTypes">
+    /// For each entity type that has derived types in the model, those derived types, base most
+    /// first. A member init always creates the type it names, so projecting such a type as a plain
+    /// member init would materialize every row as the base type and lose the derived identity.
+    /// These are instead projected as a chain of type tests, each creating the matching type.
+    /// </param>
+    public static bool TryBuild<TEntity>(
         FieldProjectionInfo projection,
-        IReadOnlyDictionary<Type, List<string>> keyNames)
+        IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        [NotNullWhen(true)] out Expression<Func<TEntity, TEntity>>? expression)
         where TEntity : class
     {
+        expression = null;
         var entityType = typeof(TEntity);
 
         if (entityType.IsAbstract)
         {
-            return null;
+            return false;
         }
 
-        var entityMetadata = GetEntityMetadata(entityType);
-        var parameter = entityMetadata.Parameter;
-        var properties = entityMetadata.Properties;
-
-        // Pre-size collections to avoid reallocations
-        var capacity = (projection.KeyNames?.Count ?? 0) + (projection.ForeignKeyNames?.Count ?? 0) +
-                      projection.ScalarFields.Count + (projection.Navigations?.Count ?? 0);
-        var bindings = new List<MemberBinding>(capacity);
-        var addedProperties = new HashSet<string>(capacity, StringComparer.OrdinalIgnoreCase);
-
-        // 1. Always include key properties
-        if (projection.KeyNames != null)
+        var parameter = GetEntityMetadata(entityType).Parameter;
+        if (!TryBuildEntityInit(parameter, entityType, projection, keyNames, derivedTypes, out var body))
         {
-            foreach (var keyName in projection.KeyNames)
-            {
-                if (properties.TryGetValue(keyName, out var metadata) &&
-                    addedProperties.Add(keyName))
-                {
-                    if (!metadata.CanWrite || !metadata.IsAutoProperty)
-                    {
-                        // Key property has a custom setter that may throw during materialization,
-                        // or is read-only. Fall back to full entity loading so EF can use backing fields.
-                        return null;
-                    }
-
-                    bindings.Add(metadata.Binding!);
-                }
-            }
+            return false;
         }
 
-        // 2. Always include foreign key properties
-        if (projection.ForeignKeyNames != null)
-        {
-            foreach (var fkName in projection.ForeignKeyNames)
-            {
-                if (properties.TryGetValue(fkName, out var metadata) &&
-                    metadata.CanWrite &&
-                    addedProperties.Add(fkName))
-                {
-                    bindings.Add(metadata.Binding!);
-                }
-            }
-        }
-
-        // 3. Add requested scalar properties
-        foreach (var fieldName in projection.ScalarFields)
-        {
-            if (properties.TryGetValue(fieldName, out var metadata) &&
-                addedProperties.Add(fieldName))
-            {
-                if (!metadata.CanWrite)
-                {
-                    // Read-only property (expression-bodied or database computed column)
-                    // Can't use projection - return null to load full entity
-                    return null;
-                }
-
-                bindings.Add(metadata.Binding!);
-            }
-        }
-
-        // 4. Add navigation properties with nested projections
-        if (projection.Navigations != null)
-        {
-            foreach (var (navFieldName, navProjection) in projection.Navigations)
-            {
-                if (!properties.TryGetValue(navFieldName, out var metadata) ||
-                    !addedProperties.Add(navFieldName))
-                {
-                    continue;
-                }
-
-                var binding = BuildNavigationBinding(metadata.PropertyAccess, navProjection, keyNames);
-                if (binding == null)
-                {
-                    if (!metadata.CanWrite)
-                    {
-                        continue;
-                    }
-
-                    // Can't project navigation (e.g. read-only properties on target entity)
-                    // Fall back to including the full navigation entity
-                    binding = BuildFullNavigationBinding(metadata, navProjection);
-                }
-
-                bindings.Add(binding);
-            }
-        }
-
-        Sort(bindings);
-
-        var memberInit = Expression.MemberInit(entityMetadata.NewInstance, bindings);
-        return Expression.Lambda<Func<TEntity, TEntity>>(memberInit, parameter);
+        expression = Expression.Lambda<Func<TEntity, TEntity>>(body, parameter);
+        return true;
     }
 
-    static MemberBinding? BuildNavigationBinding(
-        MemberExpression navAccess,
-        NavigationProjectionInfo navProjection,
-        IReadOnlyDictionary<Type, List<string>> keyNames)
-    {
-        if (navProjection.EntityType.IsAbstract)
-        {
-            return null;
-        }
-
-        return navProjection.IsCollection
-            ? BuildCollectionNavigationBinding(navAccess, navProjection, keyNames)
-            : BuildSingleNavigationBinding(navAccess, navProjection, keyNames);
-    }
-
-    static MemberAssignment? BuildCollectionNavigationBinding(
-        MemberExpression navAccess,
-        NavigationProjectionInfo navProjection,
-        IReadOnlyDictionary<Type, List<string>> keyNames)
-    {
-        var navType = navProjection.EntityType;
-        var navMetadata = GetEntityMetadata(navType);
-        var navParam = Expression.Parameter(navType, "n");
-
-        // Build the inner MemberInit for the navigation type
-        if (!TryBuildNavigationBindings(navParam, navType, navProjection.Projection, keyNames, out var innerBindings))
-        {
-            // Can't project navigation - return null to load full entity
-            return null;
-        }
-
-        var innerMemberInit = Expression.MemberInit(navMetadata.NewInstance, innerBindings);
-        var innerLambda = Expression.Lambda(innerMemberInit, navParam);
-
-        // Build: x.Children.OrderBy(_ => _.Key) to ensure deterministic ordering
-        Expression orderedCollection = navAccess;
-        if (keyNames.TryGetValue(navType, out var keys) && keys.Count > 0)
-        {
-            if (navMetadata.Properties.TryGetValue(keys[0], out var keyMetadata))
-            {
-                var keyAccess = Expression.Property(navParam, keyMetadata.Property);
-                var keyLambda = Expression.Lambda(keyAccess, navParam);
-
-                orderedCollection = Expression.Call(null, keyMetadata.OrderByMethod, navAccess, keyLambda);
-            }
-        }
-
-        // Build: x.Children.OrderBy(...).Select(n => new Child { ... })
-        var selectCall = Expression.Call(null, navMetadata.SelectMethod, orderedCollection, innerLambda);
-
-        // Build: .ToList()
-        var toListCall = Expression.Call(null, navMetadata.ToListMethod, selectCall);
-
-        return Expression.Bind(navAccess.Member, toListCall);
-    }
-
-    static MemberBinding? BuildSingleNavigationBinding(
-        MemberExpression navAccess,
-        NavigationProjectionInfo navProjection,
-        IReadOnlyDictionary<Type, List<string>> keyNames)
-    {
-        var navType = navProjection.EntityType;
-        var navMetadata = GetEntityMetadata(navType);
-
-        // x.Parent == null
-        var nullCheck = Expression.Equal(navAccess, navMetadata.NullConstant);
-
-        // Build the MemberInit for the navigation type using navAccess as source
-        if (!TryBuildNavigationBindings(navAccess, navType, navProjection.Projection, keyNames, out var innerBindings))
-        {
-            // Can't project navigation - return null to load full entity
-            return null;
-        }
-
-        var memberInit = Expression.MemberInit(navMetadata.NewInstance, innerBindings);
-
-        // x.Parent == null ? null : new Parent { ... }
-        var conditional = Expression.Condition(
-            nullCheck,
-            navMetadata.NullConstant,
-            memberInit);
-
-        return Expression.Bind(navAccess.Member, conditional);
-    }
-
-    static MemberBinding BuildFullNavigationBinding(
-        PropertyMetadata metadata,
-        NavigationProjectionInfo navProjection)
-    {
-        if (navProjection.IsCollection)
-        {
-            var navMetadata = GetEntityMetadata(navProjection.EntityType);
-            return Expression.Bind(metadata.Property, Expression.Call(null, navMetadata.ToListMethod, metadata.PropertyAccess));
-        }
-
-        return Expression.Bind(metadata.Property, metadata.PropertyAccess);
-    }
-
-    static MemberAssignment BuildFullNestedNavigationBinding(
-        PropertyInfo property,
-        MemberExpression navAccess,
-        NavigationProjectionInfo navProjection)
-    {
-        if (navProjection.IsCollection)
-        {
-            var navMetadata = GetEntityMetadata(navProjection.EntityType);
-            return Expression.Bind(property, Expression.Call(null, navMetadata.ToListMethod, navAccess));
-        }
-
-        return Expression.Bind(property, navAccess);
-    }
-
-    static bool TryBuildNavigationBindings(
-        Expression sourceExpression,
+    /// <summary>
+    /// The expression that creates <paramref name="entityType"/> from <paramref name="source"/>:
+    /// a member init, or for a type with derived types a chain of type tests each creating the
+    /// matching type, most derived first. False when the entity, or one of the navigations under
+    /// it that has no writable property to fall back to, cannot be projected.
+    /// </summary>
+    static bool TryBuildEntityInit(
+        Expression source,
         Type entityType,
         FieldProjectionInfo projection,
         IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        [NotNullWhen(true)] out Expression? expression)
+    {
+        expression = null;
+
+        if (!TryBuildMemberInit(source, entityType, projection, keyNames, derivedTypes, out var memberInit))
+        {
+            return false;
+        }
+
+        expression = memberInit;
+        if (!derivedTypes.TryGetValue(entityType, out var derived))
+        {
+            return true;
+        }
+
+        // Wrapping base most first leaves the most derived test outermost, so it runs first
+        foreach (var derivedType in derived)
+        {
+            if (derivedType.IsAbstract)
+            {
+                continue;
+            }
+
+            var derivedProjection = ProjectionForDerivedType(projection, derivedType);
+            var derivedSource = Expression.Convert(source, derivedType);
+            if (!TryBuildMemberInit(derivedSource, derivedType, derivedProjection, keyNames, derivedTypes, out var derivedInit))
+            {
+                return false;
+            }
+
+            expression = Expression.Condition(
+                Expression.TypeIs(source, derivedType),
+                Expression.Convert(derivedInit, entityType),
+                expression);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The fields selected through fragments on a derived type are recorded against the base
+    /// projection: scalars by name, which resolve against the derived type's properties, and
+    /// navigations under <see cref="FieldProjectionInfo.DerivedNavigations"/>.
+    /// </summary>
+    static FieldProjectionInfo ProjectionForDerivedType(FieldProjectionInfo projection, Type derivedType)
+    {
+        if (projection.DerivedNavigations is null ||
+            !projection.DerivedNavigations.TryGetValue(derivedType, out var derivedNavigations))
+        {
+            return projection;
+        }
+
+        return projection.Merge(new([], null, null, derivedNavigations));
+    }
+
+    static bool TryBuildMemberInit(
+        Expression source,
+        Type entityType,
+        FieldProjectionInfo projection,
+        IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        [NotNullWhen(true)] out MemberInitExpression? memberInit)
+    {
+        memberInit = null;
+        if (!TryBuildBindings(source, entityType, projection, keyNames, derivedTypes, out var bindings))
+        {
+            return false;
+        }
+
+        memberInit = Expression.MemberInit(GetEntityMetadata(entityType).NewInstance, bindings);
+        return true;
+    }
+
+    static bool TryBuildBindings(
+        Expression source,
+        Type entityType,
+        FieldProjectionInfo projection,
+        IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
         [NotNullWhen(true)] out List<MemberBinding>? bindings)
     {
         // Pre-size collections to avoid reallocations
@@ -297,7 +194,7 @@ static class SelectExpressionBuilder
                         return false;
                     }
 
-                    bindings.Add(Expression.Bind(metadata.Property, Expression.Property(sourceExpression, metadata.Property)));
+                    bindings.Add(Bind(source, metadata));
                 }
             }
         }
@@ -311,7 +208,7 @@ static class SelectExpressionBuilder
                     metadata.CanWrite &&
                     addedProperties.Add(fkName))
                 {
-                    bindings.Add(Expression.Bind(metadata.Property, Expression.Property(sourceExpression, metadata.Property)));
+                    bindings.Add(Bind(source, metadata));
                 }
             }
         }
@@ -330,14 +227,14 @@ static class SelectExpressionBuilder
                     return false;
                 }
 
-                bindings.Add(Expression.Bind(metadata.Property, Expression.Property(sourceExpression, metadata.Property)));
+                bindings.Add(Bind(source, metadata));
             }
         }
 
         // Add nested navigations recursively
         if (projection.Navigations != null)
         {
-            foreach (var (navFieldName, nestedNavProjection) in projection.Navigations)
+            foreach (var (navFieldName, navProjection) in projection.Navigations)
             {
                 if (!properties.TryGetValue(navFieldName, out var metadata) ||
                     !addedProperties.Add(navFieldName))
@@ -345,17 +242,17 @@ static class SelectExpressionBuilder
                     continue;
                 }
 
-                if (!TryBuildNestedNavigationBinding(sourceExpression, metadata.Property, nestedNavProjection, keyNames, out var binding))
+                var navAccess = Expression.Property(source, metadata.Property);
+                if (!TryBuildNavigationBinding(navAccess, navProjection, keyNames, derivedTypes, out var binding))
                 {
                     if (!metadata.CanWrite)
                     {
                         continue;
                     }
 
-                    // Can't project nested navigation (e.g. read-only properties on target entity)
+                    // Can't project navigation (e.g. read-only properties on target entity)
                     // Fall back to including the full navigation entity
-                    var navAccess = Expression.Property(sourceExpression, metadata.Property);
-                    binding = BuildFullNestedNavigationBinding(metadata.Property, navAccess, nestedNavProjection);
+                    binding = BuildFullNavigationBinding(navAccess, navProjection);
                 }
 
                 bindings.Add(binding);
@@ -367,6 +264,9 @@ static class SelectExpressionBuilder
         return true;
     }
 
+    static MemberAssignment Bind(Expression source, PropertyMetadata metadata) =>
+        Expression.Bind(metadata.Property, Expression.Property(source, metadata.Property));
+
     /// <summary>
     /// Bindings are collected in the order the fields were requested, so the same set of fields
     /// asked for in a different order produced a structurally different expression tree, and
@@ -376,11 +276,11 @@ static class SelectExpressionBuilder
     static void Sort(List<MemberBinding> bindings) =>
         bindings.Sort((x, y) => string.CompareOrdinal(x.Member.Name, y.Member.Name));
 
-    static bool TryBuildNestedNavigationBinding(
-        Expression sourceExpression,
-        PropertyInfo property,
+    static bool TryBuildNavigationBinding(
+        MemberExpression navAccess,
         NavigationProjectionInfo navProjection,
         IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
         [NotNullWhen(true)] out MemberAssignment? binding)
     {
         binding = null;
@@ -391,23 +291,18 @@ static class SelectExpressionBuilder
             return false;
         }
 
+        var navMetadata = GetEntityMetadata(navType);
+
         if (navProjection.IsCollection)
         {
-            var navMetadata = GetEntityMetadata(navType);
             var navParam = Expression.Parameter(navType, "n");
 
-            // sourceExpression.Children
-            var navAccess = Expression.Property(sourceExpression, property);
-
-            // Build the inner MemberInit
-            if (!TryBuildNavigationBindings(navParam, navType, navProjection.Projection, keyNames, out var innerBindings))
+            if (!TryBuildEntityInit(navParam, navType, navProjection.Projection, keyNames, derivedTypes, out var itemInit))
             {
-                // Can't project navigation - return false to load full entity
                 return false;
             }
 
-            var innerMemberInit = Expression.MemberInit(navMetadata.NewInstance, innerBindings);
-            var innerLambda = Expression.Lambda(innerMemberInit, navParam);
+            var itemLambda = Expression.Lambda(itemInit, navParam);
 
             // .OrderBy(_ => _.Key) to ensure deterministic ordering
             Expression orderedCollection = navAccess;
@@ -422,43 +317,40 @@ static class SelectExpressionBuilder
                 }
             }
 
-            // .Select(_ => new Child { ... })
-            var selectCall = Expression.Call(null, navMetadata.SelectMethod, orderedCollection, innerLambda);
-
-            // .ToList()
+            // .Select(_ => new Child { ... }).ToList()
+            var selectCall = Expression.Call(null, navMetadata.SelectMethod, orderedCollection, itemLambda);
             var toListCall = Expression.Call(null, navMetadata.ToListMethod, selectCall);
 
-            binding = Expression.Bind(property, toListCall);
+            binding = Expression.Bind(navAccess.Member, toListCall);
             return true;
         }
-        else
+
+        if (!TryBuildEntityInit(navAccess, navType, navProjection.Projection, keyNames, derivedTypes, out var init))
         {
-            var navMetadata = GetEntityMetadata(navType);
-
-            // sourceExpression.Parent
-            var navAccess = Expression.Property(sourceExpression, property);
-
-            // sourceExpression.Parent == null
-            var nullCheck = Expression.Equal(navAccess, navMetadata.NullConstant);
-
-            // Build the MemberInit
-            if (!TryBuildNavigationBindings(navAccess, navType, navProjection.Projection, keyNames, out var innerBindings))
-            {
-                // Can't project navigation - return false to load full entity
-                return false;
-            }
-
-            var memberInit = Expression.MemberInit(navMetadata.NewInstance, innerBindings);
-
-            // sourceExpression.Parent == null ? null : new Parent { ... }
-            var conditional = Expression.Condition(
-                nullCheck,
-                navMetadata.NullConstant,
-                memberInit);
-
-            binding = Expression.Bind(property, conditional);
-            return true;
+            return false;
         }
+
+        // source.Parent == null ? null : new Parent { ... }
+        var conditional = Expression.Condition(
+            Expression.Equal(navAccess, navMetadata.NullConstant),
+            navMetadata.NullConstant,
+            init);
+
+        binding = Expression.Bind(navAccess.Member, conditional);
+        return true;
+    }
+
+    static MemberAssignment BuildFullNavigationBinding(
+        MemberExpression navAccess,
+        NavigationProjectionInfo navProjection)
+    {
+        if (navProjection.IsCollection)
+        {
+            var navMetadata = GetEntityMetadata(navProjection.EntityType);
+            return Expression.Bind(navAccess.Member, Expression.Call(null, navMetadata.ToListMethod, navAccess));
+        }
+
+        return Expression.Bind(navAccess.Member, navAccess);
     }
 
     static EntityTypeMetadata GetEntityMetadata(Type type) =>
@@ -470,12 +362,10 @@ static class SelectExpressionBuilder
 
             foreach (var property in properties)
             {
-                var propertyAccess = Expression.Property(parameter, property);
                 var canWrite = property.CanWrite;
                 var isAutoProperty = canWrite &&
                                      property.SetMethod!.IsDefined(typeof(CompilerGeneratedAttribute), false);
-                var binding = canWrite ? Expression.Bind(property, propertyAccess) : null;
-                dictionary[property.Name] = new(type, property, canWrite, isAutoProperty, propertyAccess, binding);
+                dictionary[property.Name] = new(type, property, canWrite, isAutoProperty);
             }
 
             var newInstance = Expression.New(type);

--- a/src/Tests/IntegrationTests/Graphs/ConcreteTph/ConcreteTphBaseEntity.cs
+++ b/src/Tests/IntegrationTests/Graphs/ConcreteTph/ConcreteTphBaseEntity.cs
@@ -1,0 +1,40 @@
+// A TPH hierarchy whose base type is concrete, so rows of both types come back from the base set
+public class ConcreteTphBaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string? Property { get; set; }
+}
+
+public class ConcreteTphDerivedEntity :
+    ConcreteTphBaseEntity
+{
+    public string? DerivedProperty { get; set; }
+}
+
+public class ConcreteTphInterfaceGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+    EfInterfaceGraphType<IntegrationDbContext, ConcreteTphBaseEntity>(graphQlService);
+
+public class ConcreteTphBaseGraphType :
+    EfObjectGraphType<IntegrationDbContext, ConcreteTphBaseEntity>
+{
+    public ConcreteTphBaseGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        Name = "ConcreteTphBase";
+        AutoMap();
+        Interface<ConcreteTphInterfaceGraphType>();
+        IsTypeOf = _ => _.GetType() == typeof(ConcreteTphBaseEntity);
+    }
+}
+
+public class ConcreteTphDerivedGraphType :
+    EfObjectGraphType<IntegrationDbContext, ConcreteTphDerivedEntity>
+{
+    public ConcreteTphDerivedGraphType(IEfGraphQLService<IntegrationDbContext> graphQlService) :
+        base(graphQlService)
+    {
+        AutoMap();
+        Interface<ConcreteTphInterfaceGraphType>();
+        IsTypeOf = _ => _ is ConcreteTphDerivedEntity;
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationDbContext.cs
+++ b/src/Tests/IntegrationTests/IntegrationDbContext.cs
@@ -55,6 +55,7 @@ public class IntegrationDbContext(DbContextOptions options) :
     public DbSet<CategoryEntity> CategoryEntities { get; set; } = null!;
     public DbSet<RegionEntity> RegionEntities { get; set; } = null!;
     public DbSet<GuardedKeyEntity> GuardedKeyEntities { get; set; } = null!;
+    public DbSet<ConcreteTphBaseEntity> ConcreteTphEntities { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -179,6 +180,10 @@ public class IntegrationDbContext(DbContextOptions options) :
             entity.Property(_ => _.Id).HasField("id");
             entity.OrderBy(_ => _.EmailAddress);
         });
+        modelBuilder.Entity<ConcreteTphBaseEntity>()
+            .OrderBy(_ => _.Property);
+        modelBuilder.Entity<ConcreteTphDerivedEntity>()
+            .HasBaseType<ConcreteTphBaseEntity>();
         modelBuilder.Entity<CategoryEntity>()
             .OrderBy(_ => _.Name);
         modelBuilder.Entity<RegionEntity>()

--- a/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_denies_when_no_match.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_denies_when_no_match.verified.txt
@@ -7,6 +7,7 @@
   sql: {
     Text:
 select top (2) cast (0 as bit),
+               case when f0.Discriminator = N'FilterDerivedEntity' then cast (1 as bit) else cast (0 as bit) end,
                f0.CommonProperty,
                f.BaseEntityId,
                f.Id,

--- a/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_uses_include.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.AddSingleField_with_filter_accessing_navigation_uses_include.verified.txt
@@ -10,6 +10,7 @@
   sql: {
     Text:
 select top (2) cast (0 as bit),
+               case when f0.Discriminator = N'FilterDerivedEntity' then cast (1 as bit) else cast (0 as bit) end,
                f0.CommonProperty,
                f.BaseEntityId,
                f.Id,

--- a/src/Tests/IntegrationTests/IntegrationTests.Concrete_tph_base_keeps_derived_identity.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Concrete_tph_base_keeps_derived_identity.verified.txt
@@ -1,0 +1,26 @@
+﻿{
+  target: {
+    Data: {
+      concreteTphEntities: [
+        {
+          __typename: ConcreteTphBase,
+          property: Value1
+        },
+        {
+          __typename: ConcreteTphDerived,
+          property: Value2,
+          derivedProperty: Derived
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   case when c.Discriminator = N'ConcreteTphDerivedEntity' then cast (1 as bit) else cast (0 as bit) end,
+         c.DerivedProperty,
+         c.Id,
+         c.Property
+from     ConcreteTphEntities as c
+order by c.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Concrete_tph_base_keeps_derived_identity_single.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Concrete_tph_base_keeps_derived_identity_single.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  target: {
+    Data: {
+      concreteTphEntity: {
+        __typename: ConcreteTphDerived,
+        property: Value1,
+        derivedProperty: Derived
+      }
+    }
+  },
+  sql: {
+    Text:
+select top (2) case when c.Discriminator = N'ConcreteTphDerivedEntity' then cast (1 as bit) else cast (0 as bit) end,
+               c.DerivedProperty,
+               c.Id,
+               c.Property
+from   ConcreteTphEntities as c
+where  c.Id = @p1,
+    Parameters: {
+      @p1: Guid_1
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_TPH_inheritance_should_not_select_all_fields.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_projection_with_TPH_inheritance_should_not_select_all_fields.verified.txt
@@ -9,6 +9,7 @@
   sql: {
     Text:
 select top (2) cast (0 as bit),
+               case when f0.Discriminator = N'FilterDerivedEntity' then cast (1 as bit) else cast (0 as bit) end,
                f0.CommonProperty,
                f0.Id,
                f.BaseEntityId,

--- a/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
@@ -178,6 +178,8 @@
   tphMiddleEntity(id: ID, ids: [ID!], where: [WhereExpression!]): TphMiddleEntity
   guardedKeyEntities(id: ID, ids: [ID!], where: [WhereExpression!], orderBy: [OrderBy!], skip: Int, take: Int): [GuardedKeyEntity]!
   guardedKeyEntity(id: ID, ids: [ID!], where: [WhereExpression!]): GuardedKeyEntity
+  concreteTphEntities(id: ID, ids: [ID!], where: [WhereExpression!], orderBy: [OrderBy!], skip: Int, take: Int): [ConcreteTphBaseEntity]!
+  concreteTphEntity(id: ID, ids: [ID!], where: [WhereExpression!]): ConcreteTphBaseEntity
   tphDerivedNavEntities(id: ID, ids: [ID!], where: [WhereExpression!], orderBy: [OrderBy!], skip: Int, take: Int): [TphDerivedNavBaseEntity]!
   tphDerivedNavEntity(id: ID, ids: [ID!], where: [WhereExpression!]): TphDerivedNavBaseEntity
 }
@@ -837,6 +839,11 @@ type GuardedKeyEntity {
   id: ID!
 }
 
+interface ConcreteTphBaseEntity {
+  id: ID!
+  property: String
+}
+
 interface TphDerivedNavBaseEntity {
   id: ID!
   property: String
@@ -924,4 +931,15 @@ type TphDerivedNavRegion implements TphDerivedNavBaseEntity {
 type Region {
   id: ID!
   name: String
+}
+
+type ConcreteTphBase implements ConcreteTphBaseEntity {
+  id: ID!
+  property: String
+}
+
+type ConcreteTphDerived implements ConcreteTphBaseEntity {
+  derivedProperty: String
+  id: ID!
+  property: String
 }

--- a/src/Tests/IntegrationTests/IntegrationTests_concrete_tph.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_concrete_tph.cs
@@ -1,0 +1,65 @@
+public partial class IntegrationTests
+{
+    // A member init creates the type it names, so projecting a concrete base type materialized
+    // every row as the base and derived rows lost their identity: the derived fragment matched
+    // nothing and __typename was wrong. Types with derived types now load the full entity instead.
+    [Fact]
+    public async Task Concrete_tph_base_keeps_derived_identity()
+    {
+        var query =
+            """
+            {
+              concreteTphEntities
+              {
+                __typename
+                property
+                ... on ConcreteTphDerived
+                {
+                  derivedProperty
+                }
+              }
+            }
+            """;
+
+        var baseEntity = new ConcreteTphBaseEntity
+        {
+            Property = "Value1"
+        };
+        var derivedEntity = new ConcreteTphDerivedEntity
+        {
+            Property = "Value2",
+            DerivedProperty = "Derived"
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [baseEntity, derivedEntity]);
+    }
+
+    [Fact]
+    public async Task Concrete_tph_base_keeps_derived_identity_single()
+    {
+        var derivedEntity = new ConcreteTphDerivedEntity
+        {
+            Property = "Value1",
+            DerivedProperty = "Derived"
+        };
+
+        var query =
+            $$"""
+            {
+              concreteTphEntity(id: "{{derivedEntity.Id}}")
+              {
+                __typename
+                property
+                ... on ConcreteTphDerived
+                {
+                  derivedProperty
+                }
+              }
+            }
+            """;
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [derivedEntity]);
+    }
+}

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -412,6 +412,16 @@
             resolve: _ => _.DbContext.GuardedKeyEntities);
 
         AddQueryField(
+            name: "concreteTphEntities",
+            graphType: typeof(ConcreteTphInterfaceGraphType),
+            resolve: _ => _.DbContext.ConcreteTphEntities);
+
+        AddSingleField(
+            name: "concreteTphEntity",
+            graphType: typeof(ConcreteTphInterfaceGraphType),
+            resolve: _ => _.DbContext.ConcreteTphEntities);
+
+        AddQueryField(
             name: "tphDerivedNavEntities",
             graphType: typeof(TphDerivedNavBaseGraphType),
             resolve: _ => _.DbContext.TphDerivedNavBaseEntities);

--- a/src/Tests/IntegrationTests/Schema.cs
+++ b/src/Tests/IntegrationTests/Schema.cs
@@ -54,6 +54,8 @@
         RegisterTypeMapping(typeof(TphDerivedNavRegionEntity), typeof(TphDerivedNavRegionGraphType));
         RegisterTypeMapping(typeof(CategoryEntity), typeof(CategoryGraphType));
         RegisterTypeMapping(typeof(RegionEntity), typeof(RegionGraphType));
+        RegisterTypeMapping(typeof(ConcreteTphBaseEntity), typeof(ConcreteTphBaseGraphType));
+        RegisterTypeMapping(typeof(ConcreteTphDerivedEntity), typeof(ConcreteTphDerivedGraphType));
         Query = (Query)resolver.GetService(typeof(Query))!;
         Mutation = (Mutation)resolver.GetService(typeof(Mutation))!;
         RegisterType(typeof(DerivedGraphType));
@@ -62,5 +64,7 @@
         RegisterType(typeof(TphLeafGraphType));
         RegisterType(typeof(TphDerivedNavCategoryGraphType));
         RegisterType(typeof(TphDerivedNavRegionGraphType));
+        RegisterType(typeof(ConcreteTphBaseGraphType));
+        RegisterType(typeof(ConcreteTphDerivedGraphType));
     }
 }


### PR DESCRIPTION
A member init always creates the type it names, so projecting a base type that has derived types in the model materialized every row as the base, and derived rows lost their identity. Such a type is now projected as a chain of type tests, most derived first, each creating the matching type. EF translates each test to a discriminator check, so the base rows still get a minimal column list.

Scalars selected through a fragment on a derived type are recorded by the fragment scan, since the root sub fields exclude fields conditional on another type.