### PR TITLE
Load navigations under whole bound navigations, and return everything from a connection with no page size

### DIFF
--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -29,12 +29,16 @@
         return ApplyConnectionContext(list, first, after, last, before);
     }
 
+    /// <summary>
+    /// With neither `first` nor `last`, and no page size on the field, `first` defaulted to zero and
+    /// the connection came back with a total count but no edges. It now returns everything.
+    /// </summary>
     public static Connection<T> ApplyConnectionContext<T>(List<T> list, int? first, int? after, int? last, int? before)
         where T : class
     {
         if (last is null)
         {
-            return First(list, first.GetValueOrDefault(0), after, before, list.Count);
+            return First(list, first ?? list.Count, after, before, list.Count);
         }
 
         return Last(list, last.Value, after, before, list.Count);
@@ -144,7 +148,7 @@
         cancel.ThrowIfCancellationRequested();
         if (last is null)
         {
-            return await First(queryable, first.GetValueOrDefault(0), after, before, count, context, filters, cancel, data);
+            return await First(queryable, first ?? count, after, before, count, context, filters, cancel, data);
         }
 
         return await Last(queryable, last.Value, after, before, count, context, filters, cancel, data);

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_First.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_First.cs
@@ -165,14 +165,7 @@ partial class EfGraphQLService<TDbContext>
 
                 query = query.ApplyGraphQlArguments(context, names, false, omitQueryArguments);
 
-                if (includeAppender.TryGetProjectionExpressionWithFilters<TDbContext, TReturn>(context, fieldContext.Filters, out var selectExpr))
-                {
-                    query = query.Select(selectExpr);
-                }
-                else
-                {
-                    query = includeAppender.AddIncludes(context, fieldContext.Filters, query);
-                }
+                query = includeAppender.ApplyProjection(context, fieldContext.Filters, query);
 
                 QueryLogger.Write(query);
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Queryable.cs
@@ -114,14 +114,7 @@ partial class EfGraphQLService<TDbContext>
                         query = query.ApplyGraphQlArguments(context, names, true, omitQueryArguments);
                     }
 
-                    if (includeAppender.TryGetProjectionExpressionWithFilters<TDbContext, TReturn>(context, fieldContext.Filters, out var selectExpr))
-                    {
-                        query = query.Select(selectExpr);
-                    }
-                    else
-                    {
-                        query = includeAppender.AddIncludes(context, fieldContext.Filters, query);
-                    }
+                    query = includeAppender.ApplyProjection(context, fieldContext.Filters, query);
 
                     QueryLogger.Write(query);
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
@@ -83,14 +83,7 @@ partial class EfGraphQLService<TDbContext>
 
                 query = query.ApplyGraphQlArguments(context, names, true, omitQueryArguments);
 
-                if (includeAppender.TryGetProjectionExpressionWithFilters<TDbContext, TReturn>(context, fieldContext.Filters, out var selectExpr))
-                {
-                    query = query.Select(selectExpr);
-                }
-                else
-                {
-                    query = includeAppender.AddIncludes(context, fieldContext.Filters, query);
-                }
+                query = includeAppender.ApplyProjection(context, fieldContext.Filters, query);
 
                 try
                 {

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Single.cs
@@ -165,14 +165,7 @@ partial class EfGraphQLService<TDbContext>
 
                     query = query.ApplyGraphQlArguments(context, names, false, omitQueryArguments);
 
-                    if (includeAppender.TryGetProjectionExpressionWithFilters<TDbContext, TReturn>(context, fieldContext.Filters, out var selectExpr))
-                    {
-                        query = query.Select(selectExpr);
-                    }
-                    else
-                    {
-                        query = includeAppender.AddIncludes(context, fieldContext.Filters, query);
-                    }
+                    query = includeAppender.ApplyProjection(context, fieldContext.Filters, query);
 
                     QueryLogger.Write(query);
 

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -4,36 +4,13 @@
     IReadOnlyDictionary<Type, IReadOnlySet<string>> foreignKeys,
     IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes)
 {
-    public bool TryGetProjectionExpressionWithFilters<TDbContext, TItem>(
-        IResolveFieldContext context,
-        Filters<TDbContext>? filters,
-        [NotNullWhen(true)] out Expression<Func<TItem, TItem>>? expression)
-        where TDbContext : DbContext
-        where TItem : class
-    {
-        expression = null;
-
-        if (context.SubFields is null)
-        {
-            return false;
-        }
-
-        var type = typeof(TItem);
-        navigations.TryGetValue(type, out var navigationProperties);
-        keyNames.TryGetValue(type, out var keys);
-        foreignKeys.TryGetValue(type, out var fks);
-
-        var projection = GetProjectionInfo(context, type, navigationProperties, keys, fks);
-
-        if (filters is { HasFilters: true })
-        {
-            projection = MergeFilterFieldsIntoProjection(projection, filters, type);
-        }
-
-        return SelectExpressionBuilder.TryBuild(projection, keyNames, derivedTypes, out expression);
-    }
-
-    public IQueryable<TItem> AddIncludes<TDbContext, TItem>(
+    /// <summary>
+    /// Narrow <paramref name="query"/> to the fields the request asked for: a select projection
+    /// where the entity can be projected, otherwise includes. A projected navigation whose type
+    /// cannot be projected is bound whole, and the navigations under it are then loaded through
+    /// includes alongside the select, since EF applies includes to the entities in a projection.
+    /// </summary>
+    public IQueryable<TItem> ApplyProjection<TDbContext, TItem>(
         IResolveFieldContext context,
         Filters<TDbContext>? filters,
         IQueryable<TItem> query)
@@ -57,7 +34,17 @@
             projection = MergeFilterFieldsIntoProjection(projection, filters, type);
         }
 
-        return AddIncludesFromProjection(query, projection);
+        if (!SelectExpressionBuilder.TryBuild<TItem>(projection, keyNames, derivedTypes, out var expression, out var includePaths))
+        {
+            return AddIncludesFromProjection(query, projection);
+        }
+
+        foreach (var includePath in includePaths)
+        {
+            query = query.Include(includePath);
+        }
+
+        return query.Select(expression);
     }
 
     static IQueryable<TItem> AddIncludesFromProjection<TItem>(

--- a/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/SelectProjection/SelectExpressionBuilder.cs
@@ -1,4 +1,4 @@
-namespace GraphQL.EntityFramework;
+﻿namespace GraphQL.EntityFramework;
 
 static class SelectExpressionBuilder
 {
@@ -59,9 +59,25 @@ static class SelectExpressionBuilder
         IReadOnlyDictionary<Type, List<string>> keyNames,
         IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
         [NotNullWhen(true)] out Expression<Func<TEntity, TEntity>>? expression)
+        where TEntity : class =>
+        TryBuild(projection, keyNames, derivedTypes, out expression, out _);
+
+    /// <param name="includePaths">
+    /// The navigations under a navigation that was bound whole, because its type could not be
+    /// projected. EF applies includes to entities in a projection, so these are added as includes
+    /// alongside the select. Otherwise those deeper navigations were never loaded.
+    /// </param>
+    public static bool TryBuild<TEntity>(
+        FieldProjectionInfo projection,
+        IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        [NotNullWhen(true)] out Expression<Func<TEntity, TEntity>>? expression,
+        out IReadOnlyList<string> includePaths)
         where TEntity : class
     {
         expression = null;
+        var state = new BuildState(keyNames, derivedTypes);
+        includePaths = state.IncludePaths;
         var entityType = typeof(TEntity);
 
         if (entityType.IsAbstract)
@@ -70,7 +86,7 @@ static class SelectExpressionBuilder
         }
 
         var parameter = GetEntityMetadata(entityType).Parameter;
-        if (!TryBuildEntityInit(parameter, entityType, projection, keyNames, derivedTypes, out var body))
+        if (!TryBuildEntityInit(parameter, entityType, projection, state, null, out var body))
         {
             return false;
         }
@@ -89,19 +105,19 @@ static class SelectExpressionBuilder
         Expression source,
         Type entityType,
         FieldProjectionInfo projection,
-        IReadOnlyDictionary<Type, List<string>> keyNames,
-        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        BuildState state,
+        string? path,
         [NotNullWhen(true)] out Expression? expression)
     {
         expression = null;
 
-        if (!TryBuildMemberInit(source, entityType, projection, keyNames, derivedTypes, out var memberInit))
+        if (!TryBuildMemberInit(source, entityType, projection, state, path, out var memberInit))
         {
             return false;
         }
 
         expression = memberInit;
-        if (!derivedTypes.TryGetValue(entityType, out var derived))
+        if (!state.DerivedTypes.TryGetValue(entityType, out var derived))
         {
             return true;
         }
@@ -116,7 +132,7 @@ static class SelectExpressionBuilder
 
             var derivedProjection = ProjectionForDerivedType(projection, derivedType);
             var derivedSource = Expression.Convert(source, derivedType);
-            if (!TryBuildMemberInit(derivedSource, derivedType, derivedProjection, keyNames, derivedTypes, out var derivedInit))
+            if (!TryBuildMemberInit(derivedSource, derivedType, derivedProjection, state, path, out var derivedInit))
             {
                 return false;
             }
@@ -150,12 +166,12 @@ static class SelectExpressionBuilder
         Expression source,
         Type entityType,
         FieldProjectionInfo projection,
-        IReadOnlyDictionary<Type, List<string>> keyNames,
-        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        BuildState state,
+        string? path,
         [NotNullWhen(true)] out MemberInitExpression? memberInit)
     {
         memberInit = null;
-        if (!TryBuildBindings(source, entityType, projection, keyNames, derivedTypes, out var bindings))
+        if (!TryBuildBindings(source, entityType, projection, state, path, out var bindings))
         {
             return false;
         }
@@ -168,8 +184,8 @@ static class SelectExpressionBuilder
         Expression source,
         Type entityType,
         FieldProjectionInfo projection,
-        IReadOnlyDictionary<Type, List<string>> keyNames,
-        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        BuildState state,
+        string? path,
         [NotNullWhen(true)] out List<MemberBinding>? bindings)
     {
         // Pre-size collections to avoid reallocations
@@ -243,7 +259,8 @@ static class SelectExpressionBuilder
                 }
 
                 var navAccess = Expression.Property(source, metadata.Property);
-                if (!TryBuildNavigationBinding(navAccess, navProjection, keyNames, derivedTypes, out var binding))
+                var navPath = path is null ? metadata.Property.Name : $"{path}.{metadata.Property.Name}";
+                if (!TryBuildNavigationBinding(navAccess, navProjection, state, navPath, out var binding))
                 {
                     if (!metadata.CanWrite)
                     {
@@ -253,6 +270,7 @@ static class SelectExpressionBuilder
                     // Can't project navigation (e.g. read-only properties on target entity)
                     // Fall back to including the full navigation entity
                     binding = BuildFullNavigationBinding(navAccess, navProjection);
+                    state.AddIncludePaths(navPath, navProjection.Projection);
                 }
 
                 bindings.Add(binding);
@@ -279,8 +297,8 @@ static class SelectExpressionBuilder
     static bool TryBuildNavigationBinding(
         MemberExpression navAccess,
         NavigationProjectionInfo navProjection,
-        IReadOnlyDictionary<Type, List<string>> keyNames,
-        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes,
+        BuildState state,
+        string path,
         [NotNullWhen(true)] out MemberAssignment? binding)
     {
         binding = null;
@@ -297,7 +315,7 @@ static class SelectExpressionBuilder
         {
             var navParam = Expression.Parameter(navType, "n");
 
-            if (!TryBuildEntityInit(navParam, navType, navProjection.Projection, keyNames, derivedTypes, out var itemInit))
+            if (!TryBuildEntityInit(navParam, navType, navProjection.Projection, state, path, out var itemInit))
             {
                 return false;
             }
@@ -306,7 +324,7 @@ static class SelectExpressionBuilder
 
             // .OrderBy(_ => _.Key) to ensure deterministic ordering
             Expression orderedCollection = navAccess;
-            if (keyNames.TryGetValue(navType, out var keys) && keys.Count > 0)
+            if (state.KeyNames.TryGetValue(navType, out var keys) && keys.Count > 0)
             {
                 if (navMetadata.Properties.TryGetValue(keys[0], out var keyMetadata))
                 {
@@ -325,7 +343,7 @@ static class SelectExpressionBuilder
             return true;
         }
 
-        if (!TryBuildEntityInit(navAccess, navType, navProjection.Projection, keyNames, derivedTypes, out var init))
+        if (!TryBuildEntityInit(navAccess, navType, navProjection.Projection, state, path, out var init))
         {
             return false;
         }
@@ -351,6 +369,53 @@ static class SelectExpressionBuilder
         }
 
         return Expression.Bind(navAccess.Member, navAccess);
+    }
+
+    /// <summary>
+    /// What one build shares across its recursion: the model lookups, and the include paths
+    /// collected for navigations that were bound whole.
+    /// </summary>
+    sealed class BuildState(
+        IReadOnlyDictionary<Type, List<string>> keyNames,
+        IReadOnlyDictionary<Type, IReadOnlyList<Type>> derivedTypes)
+    {
+        public IReadOnlyDictionary<Type, List<string>> KeyNames { get; } = keyNames;
+        public IReadOnlyDictionary<Type, IReadOnlyList<Type>> DerivedTypes { get; } = derivedTypes;
+        public List<string> IncludePaths { get; } = [];
+
+        /// <summary>
+        /// A navigation bound whole is materialized as a full entity, so everything requested
+        /// under it has to arrive through includes. String include paths resolve navigations
+        /// declared on derived types too, so the derived navigations need no cast.
+        /// </summary>
+        public void AddIncludePaths(string path, FieldProjectionInfo projection)
+        {
+            if (projection.Navigations is not null)
+            {
+                foreach (var (name, nested) in projection.Navigations)
+                {
+                    AddIncludePath(path, name, nested.Projection);
+                }
+            }
+
+            if (projection.DerivedNavigations is not null)
+            {
+                foreach (var navigations in projection.DerivedNavigations.Values)
+                {
+                    foreach (var (name, nested) in navigations)
+                    {
+                        AddIncludePath(path, name, nested.Projection);
+                    }
+                }
+            }
+        }
+
+        void AddIncludePath(string path, string name, FieldProjectionInfo projection)
+        {
+            var nestedPath = $"{path}.{name}";
+            IncludePaths.Add(nestedPath);
+            AddIncludePaths(nestedPath, projection);
+        }
     }
 
     static EntityTypeMetadata GetEntityMetadata(Type type) =>

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=null_before=null.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.List_first=null_after=null_last=null_before=null.verified.txt
@@ -1,0 +1,63 @@
+﻿{
+  TotalCount: 10,
+  PageInfo: {
+    HasNextPage: false,
+    HasPreviousPage: false,
+    StartCursor: 0,
+    EndCursor: 9
+  },
+  Edges: [
+    {
+      Cursor: 0,
+      Node: a
+    },
+    {
+      Cursor: 1,
+      Node: b
+    },
+    {
+      Cursor: 2,
+      Node: c
+    },
+    {
+      Cursor: 3,
+      Node: d
+    },
+    {
+      Cursor: 4,
+      Node: e
+    },
+    {
+      Cursor: 5,
+      Node: f
+    },
+    {
+      Cursor: 6,
+      Node: g
+    },
+    {
+      Cursor: 7,
+      Node: h
+    },
+    {
+      Cursor: 8,
+      Node: i
+    },
+    {
+      Cursor: 9,
+      Node: j
+    }
+  ],
+  Items: [
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+    g,
+    h,
+    i,
+    j
+  ]
+}

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=null_before=null.verified.txt
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.Queryable_first=null_after=null_last=null_before=null.verified.txt
@@ -1,0 +1,42 @@
+﻿[
+  {
+    Id: Guid_1,
+    Property: a
+  },
+  {
+    Id: Guid_2,
+    Property: b
+  },
+  {
+    Id: Guid_3,
+    Property: c
+  },
+  {
+    Id: Guid_4,
+    Property: d
+  },
+  {
+    Id: Guid_5,
+    Property: e
+  },
+  {
+    Id: Guid_6,
+    Property: f
+  },
+  {
+    Id: Guid_7,
+    Property: g
+  },
+  {
+    Id: Guid_8,
+    Property: h
+  },
+  {
+    Id: Guid_9,
+    Property: i
+  },
+  {
+    Id: Guid_10,
+    Property: j
+  }
+]

--- a/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
+++ b/src/Tests/ConnectionConverter/ConnectionConverterTests.cs
@@ -15,6 +15,9 @@
     static SqlInstance<MyContext> sqlInstance;
 
     [Theory]
+    //no page size, the whole set
+    [InlineData(null, null, null, null)]
+
     //first after
     [InlineData(1, 0, null, null)]
     [InlineData(2, null, null, null)]
@@ -52,6 +55,9 @@
     }
 
     [Theory]
+    //no page size, the whole set
+    [InlineData(null, null, null, null)]
+
     //first after
     [InlineData(1, 0, null, null)]
     [InlineData(2, null, null, null)]

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_without_first_or_last_returns_everything.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_without_first_or_last_returns_everything.verified.txt
@@ -1,0 +1,61 @@
+﻿{
+  target: {
+    Data: {
+      childEntitiesConnection: {
+        totalCount: 3,
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: 0,
+          endCursor: 2
+        },
+        edges: [
+          {
+            cursor: 0,
+            node: {
+              property: Value1
+            }
+          },
+          {
+            cursor: 1,
+            node: {
+              property: Value2
+            }
+          },
+          {
+            cursor: 2,
+            node: {
+              property: Value3
+            }
+          }
+        ]
+      }
+    }
+  },
+  sql: [
+    {
+      Text:
+select COUNT(*)
+from   ChildEntities as c
+       left outer join
+       ParentEntities as p
+       on c.ParentId = p.Id
+    },
+    {
+      Text:
+select   c.Id,
+         c.ParentId,
+         c.Property
+from     ChildEntities as c
+         left outer join
+         ParentEntities as p
+         on c.ParentId = p.Id
+order by c.Property
+offset @p rows fetch next @p1 rows only,
+      Parameters: {
+        @p: 0,
+        @p1: 3
+      }
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_enum_projection_through_navigation.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.FieldBuilder_enum_projection_through_navigation.verified.txt
@@ -5,7 +5,22 @@
         {
           name: Parent,
           children: {
-            edges: []
+            edges: [
+              {
+                node: {
+                  name: ActiveChild,
+                  status: ACTIVE,
+                  statusDisplay: Currently Active
+                }
+              },
+              {
+                node: {
+                  name: PendingChild,
+                  status: PENDING,
+                  statusDisplay: Pending Activation
+                }
+              }
+            ]
           }
         }
       ]

--- a/src/Tests/IntegrationTests/IntegrationTests.Navigation_under_abstract_navigation_is_loaded.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Navigation_under_abstract_navigation_is_loaded.verified.txt
@@ -1,0 +1,57 @@
+﻿{
+  target: {
+    Data: {
+      derivedChildEntities: [
+        {
+          property: Child1,
+          parent: {
+            property: Parent,
+            childrenFromInterface: {
+              items: [
+                {
+                  property: Child1
+                },
+                {
+                  property: Child2
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   d.Id,
+         b.Id,
+         b.Discriminator,
+         b.Property,
+         b.Status,
+         d0.Id,
+         d0.ParentId,
+         d0.Property,
+         d0.TypedParentId,
+         d.ParentId,
+         d.Property,
+         d.TypedParentId
+from     DerivedChildEntities as d
+         left outer join
+         BaseEntities as b
+         on d.ParentId = b.Id
+         left outer join
+         DerivedChildEntities as d0
+         on b.Id = d0.ParentId
+where    d.Property = @p
+order by d.Property,
+         d.Id,
+         b.Id,
+    Parameters: {
+      @p: {
+        Value: Child1,
+        Size: 4000,
+        IsNullable: true
+      }
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_FieldBuilderExtensions.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_FieldBuilderExtensions.cs
@@ -1,4 +1,4 @@
-public partial class IntegrationTests
+﻿public partial class IntegrationTests
 {
     [Fact]
     public async Task FieldBuilder_int_value_type_projection()
@@ -384,12 +384,14 @@ public partial class IntegrationTests
         };
         var child1 = new FieldBuilderProjectionEntity
         {
+            Id = new("00000000-0000-0000-0000-000000000001"),
             Name = "ActiveChild",
             Status = EntityStatus.Active,
             Parent = parent
         };
         var child2 = new FieldBuilderProjectionEntity
         {
+            Id = new("00000000-0000-0000-0000-000000000002"),
             Name = "PendingChild",
             Status = EntityStatus.Pending,
             Parent = parent

--- a/src/Tests/IntegrationTests/IntegrationTests_abstract_navigation_includes.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_abstract_navigation_includes.cs
@@ -1,0 +1,51 @@
+public partial class IntegrationTests
+{
+    // An abstract navigation type cannot be projected, so the navigation is bound whole. The
+    // navigations requested under it were then never loaded, since nothing added an include for
+    // them. They now arrive through includes applied alongside the select.
+    [Fact]
+    public async Task Navigation_under_abstract_navigation_is_loaded()
+    {
+        var query =
+            """
+            {
+              derivedChildEntities(where: {path: "property", comparison: equal, value: "Child1"})
+              {
+                property
+                parent
+                {
+                  property
+                  childrenFromInterface(orderBy: {path: "property"})
+                  {
+                    items
+                    {
+                      property
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var parent = new DerivedEntity
+        {
+            Id = new("00000000-0000-0000-0000-000000000001"),
+            Property = "Parent"
+        };
+        var child1 = new DerivedChildEntity
+        {
+            Id = new("00000000-0000-0000-0000-000000000002"),
+            Property = "Child1",
+            Parent = parent
+        };
+        var child2 = new DerivedChildEntity
+        {
+            Id = new("00000000-0000-0000-0000-000000000003"),
+            Property = "Child2",
+            Parent = parent
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [parent, child1, child2]);
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests_connection_no_page_size.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_connection_no_page_size.cs
@@ -1,0 +1,49 @@
+public partial class IntegrationTests
+{
+    // With neither first nor last, and no page size on the field, first defaulted to zero and the
+    // connection came back with the total count but no edges. It now returns everything.
+    [Fact]
+    public async Task Connection_without_first_or_last_returns_everything()
+    {
+        var query =
+            """
+            {
+              childEntitiesConnection(orderBy: {path: "property"})
+              {
+                totalCount
+                pageInfo
+                {
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }
+                edges
+                {
+                  cursor
+                  node
+                  {
+                    property
+                  }
+                }
+              }
+            }
+            """;
+
+        var child1 = new ChildEntity
+        {
+            Property = "Value1"
+        };
+        var child2 = new ChildEntity
+        {
+            Property = "Value2"
+        };
+        var child3 = new ChildEntity
+        {
+            Property = "Value3"
+        };
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, [child1, child2, child3]);
+    }
+}


### PR DESCRIPTION


A navigation whose type cannot be projected, such as an abstract type, is bound whole in the select projection. The navigations requested under it were never loaded, since nothing added an include for them. The select builder now records the include paths below such a navigation and they are applied alongside the select, which EF honours for entities in a projection. String include paths resolve navigations declared on derived types too.

The four select or include call sites now share IncludeAppender.ApplyProjection.

With neither first nor last, and no page size on the field, a connection defaulted first to zero and came back with a total count but no edges. It now returns everything.