### PR TITLE
Remove redundant work in filter projection merging, fragment lookup and sync projection resolve

### DIFF
--- a/src/GraphQL.EntityFramework/Filters/FilterEntry.cs
+++ b/src/GraphQL.EntityFramework/Filters/FilterEntry.cs
@@ -1,4 +1,4 @@
-class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
+﻿class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
     where TDbContext : DbContext
     where TEntity : class
 {
@@ -33,8 +33,10 @@ class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
             return projection;
         }
 
-        var mergedScalars = new HashSet<string>(projection.ScalarFields, StringComparer.OrdinalIgnoreCase);
-        var navRequirements = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        // Most filters ask for fields the query already selected, so the copies are deferred
+        // until a field is actually added. Otherwise every filter copied the projection per request.
+        HashSet<string>? mergedScalars = null;
+        Dictionary<string, HashSet<string>>? navRequirements = null;
 
         foreach (var field in requiredPropertyNames)
         {
@@ -42,8 +44,10 @@ class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
             if (dotIndex < 0)
             {
                 // Scalar field - skip navigation property names
-                if (FindNavigation(navigationProperties, field) == null)
+                if (FindNavigation(navigationProperties, field) == null &&
+                    !projection.ScalarFields.Contains(field))
                 {
+                    mergedScalars ??= new(projection.ScalarFields, StringComparer.OrdinalIgnoreCase);
                     mergedScalars.Add(field);
                 }
 
@@ -59,6 +63,14 @@ class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
             }
 
             var navName = field[..dotIndex];
+            if (projection.Navigations is not null &&
+                projection.Navigations.TryGetValue(navName, out var existing) &&
+                existing.Projection.ScalarFields.Contains(navProperty))
+            {
+                continue;
+            }
+
+            navRequirements ??= new(StringComparer.OrdinalIgnoreCase);
             if (!navRequirements.TryGetValue(navName, out var props))
             {
                 props = [with(StringComparer.OrdinalIgnoreCase)];
@@ -68,60 +80,55 @@ class FilterEntry<TDbContext, TEntity, TProjection> : IFilterEntry<TDbContext>
             props.Add(navProperty);
         }
 
+        if (mergedScalars is null && navRequirements is null)
+        {
+            return projection;
+        }
+
         // Merge navigation requirements
-        Dictionary<string, NavigationProjectionInfo> mergedNavigations;
-        if (projection.Navigations == null)
+        var mergedNavigations = projection.Navigations;
+        if (navRequirements is not null)
         {
-            mergedNavigations = [];
-        }
-        else
-        {
-            mergedNavigations = new(projection.Navigations);
-        }
-
-        foreach (var (navName, requiredProps) in navRequirements)
-        {
-            var navMetadata = FindNavigation(navigationProperties, navName);
-            if (navMetadata == null)
+            mergedNavigations = mergedNavigations is null ? [] : new(mergedNavigations);
+            foreach (var (navName, requiredProps) in navRequirements)
             {
-                continue;
-            }
-
-            if (mergedNavigations.TryGetValue(navName, out var existingNav))
-            {
-                var updatedScalars = new HashSet<string>(existingNav.Projection.ScalarFields, StringComparer.OrdinalIgnoreCase);
-                updatedScalars.UnionWith(requiredProps);
-                mergedNavigations[navName] = existingNav with
+                var navMetadata = FindNavigation(navigationProperties, navName);
+                if (navMetadata == null)
                 {
-                    Projection = existingNav.Projection with { ScalarFields = updatedScalars }
-                };
-            }
-            else
-            {
-                mergedNavigations[navName] = new(navMetadata.Type, navMetadata.IsCollection, new(requiredProps, null, null, null));
+                    continue;
+                }
+
+                if (mergedNavigations.TryGetValue(navName, out var existingNav))
+                {
+                    var updatedScalars = new HashSet<string>(existingNav.Projection.ScalarFields, StringComparer.OrdinalIgnoreCase);
+                    updatedScalars.UnionWith(requiredProps);
+                    mergedNavigations[navName] = existingNav with
+                    {
+                        Projection = existingNav.Projection with { ScalarFields = updatedScalars }
+                    };
+                }
+                else
+                {
+                    mergedNavigations[navName] = new(navMetadata.Type, navMetadata.IsCollection, new(requiredProps, null, null, null));
+                }
             }
         }
 
         return projection with
         {
-            ScalarFields = mergedScalars,
+            ScalarFields = mergedScalars ?? projection.ScalarFields,
             Navigations = mergedNavigations
         };
     }
 
+    // The navigation dictionaries are built with a case insensitive comparer, so a lookup
+    // is enough. This was a linear scan comparing every key.
     static Navigation? FindNavigation(IReadOnlyDictionary<string, Navigation>? properties, string name)
     {
-        if (properties == null)
+        if (properties is not null &&
+            properties.TryGetValue(name, out var navigation))
         {
-            return null;
-        }
-
-        foreach (var (key, value) in properties)
-        {
-            if (string.Equals(key, name, StringComparison.OrdinalIgnoreCase))
-            {
-                return value;
-            }
+            return navigation;
         }
 
         return null;

--- a/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/FieldBuilderExtensions.cs
@@ -1,4 +1,4 @@
-namespace GraphQL.EntityFramework;
+﻿namespace GraphQL.EntityFramework;
 
 /// <summary>
 /// Extension methods for FieldBuilder to support projection-based resolvers.
@@ -38,8 +38,10 @@ public static class FieldBuilderExtensions
 
         var compiledProjection = projection.Compile();
 
+        // A sync resolve completes synchronously unless a filter has to run, so the resolver
+        // returns a ValueTask rather than allocating an async state machine per field per row
         field.Resolver = new FuncFieldResolver<TSource, TReturn>(
-            async context =>
+            context =>
             {
                 var projectionContext = BuildProjectionContext(graphQlService, compiledProjection, context);
 
@@ -60,7 +62,7 @@ public static class FieldBuilderExtensions
                         exception);
                 }
 
-                return await ApplyFilters(projectionContext.Filters, context, projectionContext.DbContext, result);
+                return ApplyFilters(projectionContext.Filters, context, projectionContext.DbContext, result);
             });
 
         return builder;
@@ -267,7 +269,7 @@ public static class FieldBuilderExtensions
             FieldContext = context
         };
 
-    static async Task<TReturn> ApplyFilters<TDbContext, TReturn>(
+    static ValueTask<TReturn?> ApplyFilters<TDbContext, TReturn>(
         Filters<TDbContext>? filters,
         IResolveFieldContext context,
         TDbContext dbContext,
@@ -275,18 +277,28 @@ public static class FieldBuilderExtensions
         where TDbContext : DbContext
     {
         // Value types don't support filtering - return as-is
-        if (typeof(TReturn).IsValueType)
+        if (typeof(TReturn).IsValueType ||
+            filters is not { HasFilters: true } ||
+            result is null)
         {
-            return result;
+            return new(result);
         }
 
+        return ApplyFiltersAsync(filters, context, dbContext, result);
+    }
+
+    static async ValueTask<TReturn?> ApplyFiltersAsync<TDbContext, TReturn>(
+        Filters<TDbContext> filters,
+        IResolveFieldContext context,
+        TDbContext dbContext,
+        TReturn result)
+        where TDbContext : DbContext
+    {
         // For reference types, apply filters if available. Matched on the runtime type of the
         // result, so a field typed as object is filtered the same as a typed one.
-        if (filters != null &&
-            result is not null &&
-            !await filters.ShouldInclude(context.UserContext, dbContext, context.User, (object)result))
+        if (!await filters.ShouldInclude(context.UserContext, dbContext, context.User, (object)result!))
         {
-            return default!;
+            return default;
         }
 
         return result;

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -197,14 +197,21 @@
             return projection;
         }
 
-        var updatedNavigations = new Dictionary<string, NavigationProjectionInfo>(projection.Navigations);
+        // Copied only when a nested projection changed, since most do not
+        Dictionary<string, NavigationProjectionInfo>? updatedNavigations = null;
         foreach (var (navName, navProjection) in projection.Navigations)
         {
             var updatedProjection = MergeFilterFieldsIntoProjection(navProjection.Projection, filters, navProjection.EntityType);
-            if (updatedProjection != navProjection.Projection)
+            if (!ReferenceEquals(updatedProjection, navProjection.Projection))
             {
+                updatedNavigations ??= new(projection.Navigations);
                 updatedNavigations[navName] = navProjection with { Projection = updatedProjection };
             }
+        }
+
+        if (updatedNavigations is null)
+        {
+            return projection;
         }
 
         return projection with { Navigations = updatedNavigations };
@@ -588,9 +595,7 @@
                 case GraphQLFragmentSpread fragmentSpread:
                 {
                     var name = fragmentSpread.FragmentName.Name;
-                    var fragmentDefinition = context.Document.Definitions
-                        .OfType<GraphQLFragmentDefinition>()
-                        .SingleOrDefault(_ => _.FragmentName.Name == name);
+                    var fragmentDefinition = FindFragment(context.Document, name);
 
                     if (fragmentDefinition?.SelectionSet.Selections is null)
                     {
@@ -614,6 +619,24 @@
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Validation already rejects duplicate fragment names, so the first match is the definition.
+    /// SingleOrDefault kept scanning the rest of the document after finding it.
+    /// </summary>
+    static GraphQLFragmentDefinition? FindFragment(GraphQLDocument document, GraphQLName name)
+    {
+        foreach (var definition in document.Definitions)
+        {
+            if (definition is GraphQLFragmentDefinition fragment &&
+                fragment.FragmentName.Name == name)
+            {
+                return fragment;
+            }
+        }
+
+        return null;
     }
 
     static IComplexGraphType? ResolveTypeCondition(


### PR DESCRIPTION


FilterEntry.FindNavigation scanned every key with a case insensitive compare, but the navigation dictionaries are already built with that comparer, so it is now a lookup.

AddRequirements and MergeFilterFieldsIntoProjection copied the scalar set and navigation dictionaries for every filter on every request. They now copy only when a required field is not already selected, and return the same projection instance otherwise.

The fragment definition lookup used SingleOrDefault, which kept scanning the document after the match. Validation already rejects duplicate fragment names, so a loop returns the first match.

The sync projection Resolve wrapped every call in an async lambda. It now returns a ValueTask and only goes async when a filter has to run.

Measured against main with a query exercising all of these, the difference is within noise for time and under one percent for allocations. These are cleanups of pointless work rather than a measurable improvement.