### PR TITLE
Omit query arguments from the schema on list and connection fields, and accept a null ids argument

### DIFF
--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -79,7 +79,13 @@ partial class EfGraphQLService<TDbContext>
         builder.FieldType.Type = ConnectionBuilderEx<TSource>.NonNullConnectionType(itemGraphType);
         var field = graph.AddField(builder.FieldType);
 
-        field.AddWhereArgument(hasId);
+        // The arguments were added regardless, so omitQueryArguments only stopped them being
+        // applied while the schema still advertised them
+        if (!omitQueryArguments)
+        {
+            field.AddWhereArgument(hasId);
+        }
+
         return builder;
     }
 

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
@@ -20,7 +20,7 @@ partial class EfGraphQLService<TDbContext>
         {
             Name = name,
             Type = MakeListGraphType<TReturn>(itemGraphType),
-            Arguments = ArgumentAppender.GetQueryArguments(hasId, true, false),
+            Arguments = ArgumentAppender.GetQueryArguments(hasId, true, false, omitQueryArguments),
         };
 
         IncludeAppender.SetProjectionMetadata(field, projection);
@@ -76,7 +76,7 @@ partial class EfGraphQLService<TDbContext>
         {
             Name = name,
             Type = MakeListGraphType<TReturn>(itemGraphType),
-            Arguments = ArgumentAppender.GetQueryArguments(hasId, true, false),
+            Arguments = ArgumentAppender.GetQueryArguments(hasId, true, false, omitQueryArguments),
         };
 
         IncludeAppender.SetProjectionMetadata(field, projection);

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_QueryableConnection.cs
@@ -117,8 +117,12 @@ partial class EfGraphQLService<TDbContext>
         builder.FieldType.Type = ConnectionBuilderEx<TSource>.NonNullConnectionType(itemGraphType);
         var field = graph.AddField(builder.FieldType);
 
-        var hasId = keyNames.ContainsKey(typeof(TReturn));
-        field.AddWhereArgument(hasId);
+        if (!omitQueryArguments)
+        {
+            var hasId = keyNames.ContainsKey(typeof(TReturn));
+            field.AddWhereArgument(hasId);
+        }
+
         return builder;
     }
 }

--- a/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
@@ -36,8 +36,11 @@
             return false;
         }
 
-        if (ids.Source == ArgumentSource.FieldDefault &&
-            id.Source == ArgumentSource.FieldDefault)
+        // A null ids, whether literal or from a variable, is the same as not passing it.
+        // It was dereferenced for its type name in the error below.
+        var hasIds = ids.Source != ArgumentSource.FieldDefault && ids.Value is not null;
+        var hasId = id.Source != ArgumentSource.FieldDefault;
+        if (!hasIds && !hasId)
         {
             idValues = null;
             return false;
@@ -45,7 +48,7 @@
 
         var expressions = new List<string>();
 
-        if (id.Source != ArgumentSource.FieldDefault)
+        if (hasId)
         {
             var idValue = id.Value;
             if (idValue == null)
@@ -56,7 +59,7 @@
             expressions.Add(ArgumentToExpression(idValue));
         }
 
-        if (ids.Source != ArgumentSource.FieldDefault)
+        if (hasIds)
         {
             if (ids.Value is not IEnumerable<object> objCollection)
             {

--- a/src/Tests/ArgumentProcessorTests.cs
+++ b/src/Tests/ArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-using GraphQL.Execution;
+﻿using GraphQL.Execution;
 
 public class ArgumentProcessorTests
 {
@@ -52,15 +52,42 @@ public class ArgumentProcessorTests
         Assert.Equal(["two"], result.Select(_ => _.Property));
     }
 
-    static ResolveFieldContext BuildContext(Guid id) =>
+    // A null ids was dereferenced for its type name in the unsupported type error
+    [Fact]
+    public void Null_ids_is_the_same_as_no_ids()
+    {
+        var context = BuildContext(null);
+
+        var result = new List<ParentEntity>
+            {
+                new()
+                {
+                    Property = "one"
+                },
+                new()
+                {
+                    Property = "two"
+                }
+            }
+            .ApplyGraphQlArguments(true, context, false)
+            .ToList();
+
+        Assert.Equal(["one", "two"], result.Select(_ => _.Property));
+    }
+
+    static ResolveFieldContext BuildContext(Guid? id) =>
         new()
         {
             Arguments = new Dictionary<string, ArgumentValue>
             {
-                ["ids"] = new(new object[]
-                {
-                    id.ToString()
-                }, ArgumentSource.Literal)
+                ["ids"] = new(
+                    id is null
+                        ? null
+                        : new object[]
+                        {
+                            id.ToString()!
+                        },
+                    ArgumentSource.Literal)
             },
             FieldDefinition = new()
             {

--- a/src/Tests/IntegrationTests/Graphs/ParentGraphType.cs
+++ b/src/Tests/IntegrationTests/Graphs/ParentGraphType.cs
@@ -13,6 +13,11 @@
             projection: _ => _.Children,
             resolve: _ => _.Projection,
             omitQueryArguments: true);
+        AddNavigationListField(
+            name: "childrenOmitQueryArguments",
+            projection: _ => _.Children,
+            resolve: _ => _.Projection,
+            omitQueryArguments: true);
         AutoMap();
     }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Null_ids_returns_everything.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Null_ids_returns_everything.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  target: {
+    Data: {
+      parentEntities: [
+        {
+          property: Value1
+        },
+        {
+          property: Value2
+        }
+      ]
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.SchemaPrint.verified.txt
@@ -37,6 +37,15 @@
     where: [WhereExpression!],
     orderBy: [OrderBy!],
     ids: [ID!]): ChildConnection!
+  childEntitiesConnectionOmitQueryArguments(
+    "Only return edges after the specified cursor."
+    after: String,
+    "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified."
+    first: Int,
+    "Only return edges prior to the specified cursor."
+    before: String,
+    "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified."
+    last: Int): ChildConnection!
   readOnlyEntitiesConnection(
     "Only return edges after the specified cursor."
     after: String,
@@ -323,10 +332,8 @@ type Parent {
     "Only return edges prior to the specified cursor."
     before: String,
     "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified."
-    last: Int,
-    where: [WhereExpression!],
-    orderBy: [OrderBy!],
-    ids: [ID!]): ChildConnection!
+    last: Int): ChildConnection!
+  childrenOmitQueryArguments: [Child!]!
   children(id: ID, ids: [ID!], where: [WhereExpression!], orderBy: [OrderBy!], skip: Int, take: Int): [Child!]!
   id: ID!
   property: String

--- a/src/Tests/IntegrationTests/IntegrationTests_null_ids.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests_null_ids.cs
@@ -1,0 +1,36 @@
+public partial class IntegrationTests
+{
+    // A null ids argument was dereferenced for its type name while building the unsupported
+    // type error. It is now the same as not passing ids.
+    [Fact]
+    public async Task Null_ids_returns_everything()
+    {
+        var query =
+            """
+            query($ids: [ID!])
+            {
+              parentEntities(ids: $ids, orderBy: {path: "property"})
+              {
+                property
+              }
+            }
+            """;
+
+        var entity1 = new ParentEntity
+        {
+            Property = "Value1"
+        };
+        var entity2 = new ParentEntity
+        {
+            Property = "Value2"
+        };
+
+        var inputs = new Inputs(new Dictionary<string, object?>
+        {
+            ["ids"] = null
+        });
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, inputs, null, false, [entity1, entity2]);
+    }
+}

--- a/src/Tests/IntegrationTests/Query.cs
+++ b/src/Tests/IntegrationTests/Query.cs
@@ -80,6 +80,12 @@
             name: "childEntitiesConnection",
             resolve: _ => _.DbContext.ChildEntities.OrderBy(_ => _.Parent));
 
+        efGraphQlService.AddQueryConnectionField<ChildGraphType, ChildEntity>(
+            this,
+            name: "childEntitiesConnectionOmitQueryArguments",
+            resolve: _ => _.DbContext.ChildEntities.OrderBy(_ => _.Property),
+            omitQueryArguments: true);
+
         // Connection with entity that has read-only properties.
         // Projection bails on read-only properties, falling back to AddIncludes.
         // Include() strips IOrderedQueryable, testing that the ordering check


### PR DESCRIPTION


Navigation list, navigation connection and query connection fields still added where, orderBy, ids, skip and take when omitQueryArguments was set. The flag only stopped them being applied, so the schema advertised arguments that did nothing. The builders now skip adding them.

A null ids argument, whether a literal or a variable, was dereferenced for its type name while building the unsupported type error. It is now the same as not passing ids.