### PR TITLE
Drop the per row context copy in navigation resolvers, and page connections with one query

### DIFF
--- a/docs/defining-graphs.md
+++ b/docs/defining-graphs.md
@@ -351,6 +351,8 @@ Creating a page-able field is supported through [GraphQL Connections](https://gr
 
 Cursors are the zero based index of the edge in the ordered set. `after` and `before` are exclusive, and bound the window of items a page is taken from. `first` keeps that many from the start of the window, then `last` keeps that many from the end, in the order the [Relay specification](https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm) applies them. Edges are always in the set's order, whichever end the page was taken from. `hasPreviousPage` is true when the page starts after the first item, `hasNextPage` when items exist after the page. An empty page has null `startCursor` and `endCursor`.
 
+A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` or `pageInfo` is selected, or when paging with `last` or `before`, which place the window from the end. A selection of only `edges` or `items`, paged with `first` and `after`, is a single query.
+
 
 ### Root Query
 

--- a/docs/defining-graphs.md
+++ b/docs/defining-graphs.md
@@ -351,7 +351,7 @@ Creating a page-able field is supported through [GraphQL Connections](https://gr
 
 Cursors are the zero based index of the edge in the ordered set. `after` and `before` are exclusive, and bound the window of items a page is taken from. `first` keeps that many from the start of the window, then `last` keeps that many from the end, in the order the [Relay specification](https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm) applies them. Edges are always in the set's order, whichever end the page was taken from. `hasPreviousPage` is true when the page starts after the first item, `hasNextPage` when items exist after the page. An empty page has null `startCursor` and `endCursor`.
 
-A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` or `pageInfo` is selected, or when paging with `last` or `before`, which place the window from the end. A selection of only `edges` or `items`, paged with `first` and `after`, is a single query.
+A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` is selected, or when paging with `last` or `before`, which place the window from the end. Paged with `first` and `after`, a selection of `edges`, `items` and `pageInfo` is a single query: it reads one row past the page, and that row answers `hasNextPage`. Without the count, an empty page past the end reports `hasPreviousPage` false, which the Relay specification allows when paging forward.
 
 
 ### Root Query

--- a/docs/mdsource/defining-graphs.source.md
+++ b/docs/mdsource/defining-graphs.source.md
@@ -247,7 +247,7 @@ Creating a page-able field is supported through [GraphQL Connections](https://gr
 
 Cursors are the zero based index of the edge in the ordered set. `after` and `before` are exclusive, and bound the window of items a page is taken from. `first` keeps that many from the start of the window, then `last` keeps that many from the end, in the order the [Relay specification](https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm) applies them. Edges are always in the set's order, whichever end the page was taken from. `hasPreviousPage` is true when the page starts after the first item, `hasNextPage` when items exist after the page. An empty page has null `startCursor` and `endCursor`.
 
-A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` or `pageInfo` is selected, or when paging with `last` or `before`, which place the window from the end. A selection of only `edges` or `items`, paged with `first` and `after`, is a single query.
+A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` is selected, or when paging with `last` or `before`, which place the window from the end. Paged with `first` and `after`, a selection of `edges`, `items` and `pageInfo` is a single query: it reads one row past the page, and that row answers `hasNextPage`. Without the count, an empty page past the end reports `hasPreviousPage` false, which the Relay specification allows when paging forward.
 
 
 ### Root Query

--- a/docs/mdsource/defining-graphs.source.md
+++ b/docs/mdsource/defining-graphs.source.md
@@ -247,6 +247,8 @@ Creating a page-able field is supported through [GraphQL Connections](https://gr
 
 Cursors are the zero based index of the edge in the ordered set. `after` and `before` are exclusive, and bound the window of items a page is taken from. `first` keeps that many from the start of the window, then `last` keeps that many from the end, in the order the [Relay specification](https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm) applies them. Edges are always in the set's order, whichever end the page was taken from. `hasPreviousPage` is true when the page starts after the first item, `hasNextPage` when items exist after the page. An empty page has null `startCursor` and `endCursor`.
 
+A root connection reads its items with one query and the total with another. The count query only runs when the selection needs it: when `totalCount` or `pageInfo` is selected, or when paging with `last` or `before`, which place the window from the end. A selection of only `edges` or `items`, paged with `first` and `after`, is a single query.
+
 
 ### Root Query
 

--- a/src/Benchmarks/RequestSplitBenchmark.cs
+++ b/src/Benchmarks/RequestSplitBenchmark.cs
@@ -39,6 +39,19 @@ public class RequestSplitBenchmark
         }
         """;
 
+    const string inMemoryArgumentsQuery = """
+        {
+          parents {
+            id
+            property
+            childrenReversed(where: {property: {startsWith: "Child"}}, orderBy: {property: descending}) {
+              id
+              property
+            }
+          }
+        }
+        """;
+
     const string fragmentsQuery = """
         {
           parents {
@@ -111,6 +124,7 @@ public class RequestSplitBenchmark
         await Execute(librarySchema, argumentsQuery);
         capturedArguments = CapturingQuery.Captured!;
         await Execute(librarySchema, fragmentsQuery);
+        await Execute(librarySchema, inMemoryArgumentsQuery);
         await Execute(plainSchema, simpleQuery);
 
         projected = includeAppender.ApplyProjection<BenchmarkDbContext, ParentEntity>(capturedSimple, null, Parents);
@@ -152,6 +166,14 @@ public class RequestSplitBenchmark
     [Benchmark]
     public Task<int> FullWithFragments() =>
         Execute(librarySchema, fragmentsQuery);
+
+    /// <summary>
+    /// The where and orderBy of a navigation whose resolver returns a collection other than the
+    /// projected one, so they are evaluated in memory in the resolver, once per parent row.
+    /// </summary>
+    [Benchmark]
+    public Task<int> FullWithInMemoryArguments() =>
+        Execute(librarySchema, inMemoryArgumentsQuery);
 
     [Benchmark]
     public System.Linq.Expressions.Expression ApplyArguments() =>

--- a/src/Benchmarks/SimpleQueryBenchmark.cs
+++ b/src/Benchmarks/SimpleQueryBenchmark.cs
@@ -40,6 +40,12 @@ public class ParentGraphType :
             name: "children",
             projection: _ => _.Children,
             resolve: _ => _.Projection);
+        // Returns a collection other than the projected one, so its arguments are applied in
+        // memory, once per parent row
+        AddNavigationListField(
+            name: "childrenReversed",
+            projection: _ => _.Children,
+            resolve: _ => _.Projection.Reverse());
         AutoMap();
     }
 }

--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -39,7 +39,8 @@
         var count = list.Count;
         var (skip, take) = Window(first, after, last, before, count);
         var page = list.Skip(skip).Take(take);
-        return Build(skip, take, count, page);
+        // long, since a large `first` makes take + skip overflow and wrap negative
+        return Build(skip, count, skip > 0, count > (long) take + skip, page);
     }
 
     /// <summary>
@@ -114,48 +115,70 @@
         }
 
         int skip;
-        int take;
         int? count = null;
-        IQueryable<TItem> page;
+        bool hasPreviousPage;
+        bool hasNextPage;
+        List<TItem> rows;
         if (NeedsCount(context, last, before))
         {
             count = await queryable.CountAsync(cancel);
             cancel.ThrowIfCancellationRequested();
+            int take;
             (skip, take) = Window(first, after, last, before, count.Value);
-            page = queryable.Skip(skip).Take(take);
+            var page = queryable.Skip(skip).Take(take);
+            QueryLogger.Write(page);
+            rows = await page.ToListAsync(cancel);
+            hasPreviousPage = skip > 0;
+            // long, since a large `first` makes take + skip overflow and wrap negative
+            hasNextPage = count > (long) take + skip;
         }
         else
         {
             // The window is bounded from the start only, so it needs no count to place it. The
             // count clamped the offset to the end; past it the page query reads an empty page.
             skip = after + 1 ?? 0;
-            // Only compared against the count, which is unknown here
-            take = first ?? 0;
-            page = queryable.Skip(skip);
+            var page = queryable.Skip(skip);
             if (first is not null)
             {
-                page = page.Take(first.Value);
+                // One row past the page says whether a next page exists
+                page = page.Take(Peek(first.Value));
+            }
+
+            QueryLogger.Write(page);
+            rows = await page.ToListAsync(cancel);
+            hasNextPage = first is not null && rows.Count > first.Value;
+            // Rows on the page prove rows before it. An empty page proves nothing, and paging
+            // forward the spec allows false when that is unknown.
+            hasPreviousPage = skip > 0 && rows.Count > 0;
+            if (hasNextPage)
+            {
+                rows.RemoveAt(rows.Count - 1);
             }
         }
 
-        QueryLogger.Write(page);
-        IEnumerable<TItem> result = await page.ToListAsync(cancel);
+        IEnumerable<TItem> result = rows;
         if (filters != null)
         {
             result = await filters.ApplyFilter(result, context.UserContext, data, context.User);
         }
 
         cancel.ThrowIfCancellationRequested();
-        return Build(skip, take, count, result);
+        return Build(skip, count, hasPreviousPage, hasNextPage, result);
     }
 
     /// <summary>
-    /// Whether the count query has to run: when the selection reads it, through totalCount or
-    /// the page info, whose hasNextPage compares against it, or when the window is bounded from
-    /// the end, by last or before, so the count is needed to place it. A connection selecting
-    /// only edges or items otherwise paid a second round trip, a COUNT over the whole filtered
-    /// set, for a number nothing read. The selection is unknown for a context built outside an
-    /// execution, which counts.
+    /// The page size plus the one row read past it, capped so the largest page size does not wrap.
+    /// </summary>
+    static int Peek(int first) =>
+        first == int.MaxValue ? first : first + 1;
+
+    /// <summary>
+    /// Whether the count query has to run: when totalCount is selected, or when the window is
+    /// bounded from the end, by last or before, so the count is needed to place it. The page
+    /// info alone does not need it, since hasNextPage is answered by the row read past the page.
+    /// A connection selecting edges, items and page info otherwise paid a second round trip, a
+    /// COUNT over the whole filtered set, for a number nothing read. The selection is unknown
+    /// for a context built outside an execution, which counts.
     /// </summary>
     static bool NeedsCount(IResolveFieldContext context, int? last, int? before)
     {
@@ -173,9 +196,7 @@
 
         foreach (var (field, _) in subFields.Values)
         {
-            var name = field.Name.Value;
-            if (name.Equals("totalCount") ||
-                name.Equals("pageInfo"))
+            if (field.Name.Value.Equals("totalCount"))
             {
                 return true;
             }
@@ -184,8 +205,8 @@
         return false;
     }
 
-    /// <param name="count">Null when the count query was skipped, which only happens when neither the total count nor the page info was selected.</param>
-    static Connection<T> Build<T>(int skip, int take, int? count, IEnumerable<T> result)
+    /// <param name="count">Null when the count query was skipped, which only happens when the total count was not selected.</param>
+    static Connection<T> Build<T>(int skip, int? count, bool hasPreviousPage, bool hasNextPage, IEnumerable<T> result)
     {
         var edges = result
             .Select((item, index) =>
@@ -202,9 +223,8 @@
             Edges = edges,
             PageInfo = new()
             {
-                // long, since a large `first` makes take + skip overflow and wrap negative
-                HasNextPage = count > (long) take + skip,
-                HasPreviousPage = skip > 0,
+                HasNextPage = hasNextPage,
+                HasPreviousPage = hasPreviousPage,
                 // Null when there are no edges, as the spec has it. The edges are used rather
                 // than the window since filters can remove items after the query.
                 StartCursor = edges.FirstOrDefault()?.Cursor,

--- a/src/GraphQL.EntityFramework/ConnectionConverter.cs
+++ b/src/GraphQL.EntityFramework/ConnectionConverter.cs
@@ -112,10 +112,32 @@
         {
             throw new($"Connections require ordering. Either order the IQueryable being passed to AddQueryConnectionField, or use an orderBy in the query. Field: {context.FieldDefinition.Name}");
         }
-        var count = await queryable.CountAsync(cancel);
-        cancel.ThrowIfCancellationRequested();
-        var (skip, take) = Window(first, after, last, before, count);
-        var page = queryable.Skip(skip).Take(take);
+
+        int skip;
+        int take;
+        int? count = null;
+        IQueryable<TItem> page;
+        if (NeedsCount(context, last, before))
+        {
+            count = await queryable.CountAsync(cancel);
+            cancel.ThrowIfCancellationRequested();
+            (skip, take) = Window(first, after, last, before, count.Value);
+            page = queryable.Skip(skip).Take(take);
+        }
+        else
+        {
+            // The window is bounded from the start only, so it needs no count to place it. The
+            // count clamped the offset to the end; past it the page query reads an empty page.
+            skip = after + 1 ?? 0;
+            // Only compared against the count, which is unknown here
+            take = first ?? 0;
+            page = queryable.Skip(skip);
+            if (first is not null)
+            {
+                page = page.Take(first.Value);
+            }
+        }
+
         QueryLogger.Write(page);
         IEnumerable<TItem> result = await page.ToListAsync(cancel);
         if (filters != null)
@@ -127,7 +149,43 @@
         return Build(skip, take, count, result);
     }
 
-    static Connection<T> Build<T>(int skip, int take, int count, IEnumerable<T> result)
+    /// <summary>
+    /// Whether the count query has to run: when the selection reads it, through totalCount or
+    /// the page info, whose hasNextPage compares against it, or when the window is bounded from
+    /// the end, by last or before, so the count is needed to place it. A connection selecting
+    /// only edges or items otherwise paid a second round trip, a COUNT over the whole filtered
+    /// set, for a number nothing read. The selection is unknown for a context built outside an
+    /// execution, which counts.
+    /// </summary>
+    static bool NeedsCount(IResolveFieldContext context, int? last, int? before)
+    {
+        if (last is not null ||
+            before is not null)
+        {
+            return true;
+        }
+
+        var subFields = context.SubFields;
+        if (subFields is null)
+        {
+            return true;
+        }
+
+        foreach (var (field, _) in subFields.Values)
+        {
+            var name = field.Name.Value;
+            if (name.Equals("totalCount") ||
+                name.Equals("pageInfo"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <param name="count">Null when the count query was skipped, which only happens when neither the total count nor the page info was selected.</param>
+    static Connection<T> Build<T>(int skip, int take, int? count, IEnumerable<T> result)
     {
         var edges = result
             .Select((item, index) =>

--- a/src/GraphQL.EntityFramework/Filters/Filters.cs
+++ b/src/GraphQL.EntityFramework/Filters/Filters.cs
@@ -93,6 +93,7 @@ public class Filters<TDbContext>
 
         forType.Add(entry);
         filtersByType.Clear();
+        filtersForHierarchy.Clear();
     }
 
     /// <summary>
@@ -116,10 +117,17 @@ public class Filters<TDbContext>
     /// load: those on the type and its base types, which apply to every item, and those on derived
     /// types, which apply to the derived items the query can return.
     /// </summary>
-    internal IEnumerable<IFilterEntry<TDbContext>> GetFiltersForHierarchy(Type entityType) =>
-        entries
-            .Where(_ => _.Key.IsAssignableFrom(entityType) || entityType.IsAssignableFrom(_.Key))
-            .SelectMany(_ => _.Value);
+    internal IReadOnlyList<IFilterEntry<TDbContext>> GetFiltersForHierarchy(Type entityType) =>
+        filtersForHierarchy.GetOrAdd(
+            entityType,
+            type => entries
+                .Where(_ => _.Key.IsAssignableFrom(type) || type.IsAssignableFrom(_.Key))
+                .SelectMany(_ => _.Value)
+                .ToList());
+
+    // Looked up for every entity type in a projection on every request, so cached per type the
+    // same way as GetFilters, and reset when a filter is added
+    ConcurrentDictionary<Type, List<IFilterEntry<TDbContext>>> filtersForHierarchy = new();
 
     /// <summary>
     /// Returns true if there are any filters registered.

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Navigation.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_Navigation.cs
@@ -28,15 +28,20 @@ partial class EfGraphQLService<TDbContext>
         field.Resolver = new FuncFieldResolver<TSource, TReturn?>(
             async context =>
             {
-                var fieldContext = BuildContext(context);
+                // Runs once per parent row. Building a ResolveEfFieldContext here copied every property
+                // of the GraphQL.NET context, which forced the lazily computed ones, SubFields, Path,
+                // ResponsePath, Parent and Arguments, to be computed and allocated per row, when all
+                // this needs is the DbContext and the filters.
+                var dbContext = ResolveDbContext(context);
+                var filters = ResolveFilters(context);
                 var projected = compiledProjection(context.Source);
 
                 var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
                 {
                     Projection = projected,
-                    DbContext = fieldContext.DbContext,
+                    DbContext = dbContext,
                     User = context.User,
-                    Filters = fieldContext.Filters,
+                    Filters = filters,
                     FieldContext = context
                 };
 
@@ -57,12 +62,12 @@ partial class EfGraphQLService<TDbContext>
                         exception);
                 }
 
-                if (fieldContext.Filters == null)
+                if (filters == null)
                 {
                     return result;
                 }
 
-                if (await fieldContext.Filters.ShouldInclude(context.UserContext, fieldContext.DbContext, context.User, result))
+                if (await filters.ShouldInclude(context.UserContext, dbContext, context.User, result))
                 {
                     return result;
                 }

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationConnection.cs
@@ -26,15 +26,20 @@ partial class EfGraphQLService<TDbContext>
         var names = GetKeyNames<TReturn>();
         builder.ResolveAsync(async context =>
         {
-            var efFieldContext = BuildContext(context);
+            // Runs once per parent row. Building a ResolveEfFieldContext here copied every property
+            // of the GraphQL.NET context, which forced the lazily computed ones, SubFields, Path,
+            // ResponsePath, Parent and Arguments, to be computed and allocated per row, when all
+            // this needs is the DbContext and the filters.
+            var dbContext = ResolveDbContext(context);
+            var filters = ResolveFilters(context);
             var projected = compiledProjection(context.Source);
 
             var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
             {
                 Projection = projected,
-                DbContext = efFieldContext.DbContext,
+                DbContext = dbContext,
                 User = context.User,
-                Filters = efFieldContext.Filters,
+                Filters = filters,
                 FieldContext = context
             };
 
@@ -59,11 +64,17 @@ partial class EfGraphQLService<TDbContext>
                 throw new("This API expects the resolver to return a IEnumerable, not an IQueryable. Instead use AddQueryConnectionField.");
             }
 
-            var applied = ReferenceEquals(enumerable, projected) && PushDown.IsApplied(context);
-            enumerable = enumerable.ApplyGraphQlArguments(names, context, omitQueryArguments, applied);
-            if (efFieldContext.Filters != null)
+            // A field selected without arguments has nothing to apply, so the argument reads
+            // and the push down lookup are skipped
+            if (ArgumentReader.HasArguments(context))
             {
-                enumerable = await efFieldContext.Filters.ApplyFilter(enumerable, context.UserContext, efFieldContext.DbContext, context.User);
+                var applied = ReferenceEquals(enumerable, projected) && PushDown.IsApplied(context);
+                enumerable = enumerable.ApplyGraphQlArguments(names, context, omitQueryArguments, applied);
+            }
+
+            if (filters != null)
+            {
+                enumerable = await filters.ApplyFilter(enumerable, context.UserContext, dbContext, context.User);
             }
 
             var page = enumerable.ToList();

--- a/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/EfGraphQLService_NavigationList.cs
@@ -29,15 +29,20 @@ partial class EfGraphQLService<TDbContext>
 
         field.Resolver = new FuncFieldResolver<TSource, IEnumerable<TReturn>>(async context =>
         {
-            var fieldContext = BuildContext(context);
+            // Runs once per parent row. Building a ResolveEfFieldContext here copied every property
+            // of the GraphQL.NET context, which forced the lazily computed ones, SubFields, Path,
+            // ResponsePath, Parent and Arguments, to be computed and allocated per row, when all
+            // this needs is the DbContext and the filters.
+            var dbContext = ResolveDbContext(context);
+            var filters = ResolveFilters(context);
             var projected = compiledProjection(context.Source);
 
             var projectionContext = new ResolveProjectionContext<TDbContext, TProjection>
             {
                 Projection = projected,
-                DbContext = fieldContext.DbContext,
+                DbContext = dbContext,
                 User = context.User,
-                Filters = fieldContext.Filters,
+                Filters = filters,
                 FieldContext = context
             };
 
@@ -48,16 +53,22 @@ partial class EfGraphQLService<TDbContext>
                 throw new("This API expects the resolver to return a IEnumerable, not an IQueryable. Instead use AddQueryField.");
             }
 
-            // The collection arrives with ids, where and orderBy already applied when the parent
-            // was loaded through a projection and the resolver returned that collection as is
-            var applied = ReferenceEquals(result, projected) && PushDown.IsApplied(context);
-            result = result.ApplyGraphQlArguments(names, context, omitQueryArguments, applied);
-            if (fieldContext.Filters == null)
+            // A field selected without arguments has nothing to apply, and that is the common
+            // case for a navigation, so the argument reads and the push down lookup are skipped
+            if (ArgumentReader.HasArguments(context))
+            {
+                // The collection arrives with ids, where and orderBy already applied when the parent
+                // was loaded through a projection and the resolver returned that collection as is
+                var applied = ReferenceEquals(result, projected) && PushDown.IsApplied(context);
+                result = result.ApplyGraphQlArguments(names, context, omitQueryArguments, applied);
+            }
+
+            if (filters == null)
             {
                 return result;
             }
 
-            return await fieldContext.Filters.ApplyFilter(result, context.UserContext, fieldContext.DbContext, context.User);
+            return await filters.ApplyFilter(result, context.UserContext, dbContext, context.User);
         });
 
         graph.AddField(field);

--- a/src/GraphQL.EntityFramework/GraphApi/ProjectionPaths.cs
+++ b/src/GraphQL.EntityFramework/GraphApi/ProjectionPaths.cs
@@ -1,0 +1,79 @@
+﻿/// <summary>
+/// The property paths a projection expression reads, grouped by the root property each starts
+/// from, in the order the expression reads them. Analyzed once when the field is registered and
+/// kept in the field metadata. It was analyzed again on every request that selected the field,
+/// with a visitor walk over the expression and the grouping rebuilt each time.
+/// </summary>
+sealed class ProjectionPaths
+{
+    ProjectionPaths(IReadOnlyList<ProjectionPathGroup> groups) =>
+        Groups = groups;
+
+    public IReadOnlyList<ProjectionPathGroup> Groups { get; }
+
+    /// <summary>
+    /// The root of the first path read. It receives the field's selection set when the type the
+    /// field returns cannot say which navigation the selection applies to.
+    /// </summary>
+    public string? PrimaryRoot =>
+        Groups.Count == 0 ? null : Groups[0].Root;
+
+    public static ProjectionPaths Analyze(LambdaExpression projection)
+    {
+        var groups = new List<ProjectionPathGroup>();
+        var byRoot = new Dictionary<string, ProjectionPathGroup>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in ProjectionAnalyzer.ExtractPropertyPaths(projection))
+        {
+            var dotIndex = path.IndexOf('.');
+            var root = dotIndex >= 0 ? path[..dotIndex] : path;
+
+            if (!byRoot.TryGetValue(root, out var group))
+            {
+                group = new(root);
+                byRoot[root] = group;
+                groups.Add(group);
+            }
+
+            if (dotIndex >= 0)
+            {
+                group.Add(path[(dotIndex + 1)..]);
+            }
+        }
+
+        return new(groups);
+    }
+}
+
+/// <summary>
+/// The paths read below one property of the entity.
+/// </summary>
+sealed class ProjectionPathGroup(string root)
+{
+    List<string> nested = [];
+    List<string> nestedScalars = [];
+
+    /// <summary>
+    /// The property on the entity the paths start from.
+    /// </summary>
+    public string Root { get; } = root;
+
+    /// <summary>
+    /// The paths below <see cref="Root"/>, without it. Empty when the root was read whole.
+    /// </summary>
+    public IReadOnlyList<string> Nested => nested;
+
+    /// <summary>
+    /// The single segment paths in <see cref="Nested"/>: the scalars read from the navigation.
+    /// </summary>
+    public IReadOnlyList<string> NestedScalars => nestedScalars;
+
+    internal void Add(string path)
+    {
+        nested.Add(path);
+        if (!path.Contains('.'))
+        {
+            nestedScalars.Add(path);
+        }
+    }
+}

--- a/src/GraphQL.EntityFramework/IncludeAppender.cs
+++ b/src/GraphQL.EntityFramework/IncludeAppender.cs
@@ -329,7 +329,8 @@
     {
         IComplexGraphType? leafGraphType;
         (selectionSet, leafGraphType) = GetLeafSelection(selectionSet, graphType);
-        if (selectionSet?.Selections is null)
+        if (selectionSet?.Selections is null ||
+            !HasFragments(selectionSet))
         {
             return null;
         }
@@ -386,6 +387,24 @@
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Only a fragment can select from a type other than the parent's, so a selection set of plain
+    /// fields has no derived navigations to collect, and the walk over it is skipped. Most
+    /// selection sets are plain fields, and the walk ran for every one on every request.
+    /// </summary>
+    static bool HasFragments(GraphQLSelectionSet selectionSet)
+    {
+        foreach (var selection in selectionSet.Selections)
+        {
+            if (selection is not GraphQLField)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -552,44 +571,20 @@
         GraphQLField field,
         FieldType fieldType,
         IComplexGraphType? parentGraphType,
-        LambdaExpression projection,
+        ProjectionPaths projection,
         IReadOnlyDictionary<string, Navigation>? navigationProperties,
         HashSet<string> scalarFields,
         Dictionary<string, NavigationProjectionInfo> navProjections,
         IResolveFieldContext context)
     {
-        var accessedPaths = ProjectionAnalyzer.ExtractPropertyPaths(projection);
-
-        // Group paths by their root navigation property
-        var pathsByNavigation = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-        string? primaryNavigation = null;
-
-        foreach (var path in accessedPaths)
-        {
-            var dotIndex = path.IndexOf('.');
-            var rootProperty = dotIndex >= 0 ? path[..dotIndex] : path;
-
-            if (!pathsByNavigation.TryGetValue(rootProperty, out var paths))
-            {
-                paths = [];
-                pathsByNavigation[rootProperty] = paths;
-            }
-
-            if (dotIndex >= 0)
-            {
-                paths.Add(path[(dotIndex + 1)..]);
-            }
-
-            primaryNavigation ??= rootProperty;
-        }
-
         // The field's selection set applies to the navigations of the type the field returns.
         // It used to go to whichever path the analyzer visited first, so with `new { _.Child2,
         // _.Child1 }` resolving Child1, Child2 got the selection and Child1 got nothing under it.
         var itemType = FieldItemType(fieldType);
 
-        foreach (var (navName, nestedPaths) in pathsByNavigation)
+        foreach (var group in projection.Groups)
         {
+            var navName = group.Root;
             if (!TryFindNavigation(navigationProperties, navName, out var navigation))
             {
                 // Scalar field path (no navigation) — add root property to scalarFields
@@ -598,7 +593,7 @@
             }
 
             var receivesSelection = itemType is null
-                ? navName == primaryNavigation
+                ? navName == projection.PrimaryRoot
                 : itemType.IsAssignableFrom(navigation.Type) || navigation.Type.IsAssignableFrom(itemType);
 
             var navType = navigation.Type;
@@ -612,27 +607,24 @@
             // A navigation accessed as a whole, with nothing read from it in the expression and no
             // selection set to say which fields are wanted, needs the whole entity. It was
             // projected with only its keys, so the resolver saw every other property as null.
-            var isWhole = nestedPaths.Count == 0;
+            var isWhole = group.Nested.Count == 0;
 
             if (receivesSelection && field.SelectionSet is not null)
             {
                 // A navigation list or connection field projecting the collection itself. Its ids,
                 // where and orderBy are applied inside the collection subquery.
                 if (navigation.IsCollection &&
-                    pathsByNavigation.Count == 1 &&
-                    nestedPaths.Count == 0)
+                    projection.Groups.Count == 1 &&
+                    group.Nested.Count == 0)
                 {
                     arguments = ReadArguments(field, fieldType, parentGraphType, context);
                 }
 
                 // Primary navigation: merge GraphQL fields with projection-required fields
                 nestedProjection = GetNestedProjection(field.SelectionSet, GetComplexGraphType(fieldType), navType, nestedNavProps, nestedKeys, nestedFks, context);
-                foreach (var nestedPath in nestedPaths)
+                foreach (var nestedPath in group.NestedScalars)
                 {
-                    if (!nestedPath.Contains('.'))
-                    {
-                        nestedProjection.ScalarFields.Add(nestedPath);
-                    }
+                    nestedProjection.ScalarFields.Add(nestedPath);
                 }
 
                 isWhole = false;
@@ -640,9 +632,7 @@
             else
             {
                 // Secondary navigation: include only projection-required fields
-                var nestedScalarFields = nestedPaths
-                    .Where(_ => !_.Contains('.'))
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var nestedScalarFields = new HashSet<string>(group.NestedScalars, StringComparer.OrdinalIgnoreCase);
 
                 nestedProjection = new(nestedScalarFields, nestedKeys ?? [], nestedFks ?? new HashSet<string>(), []);
             }
@@ -869,14 +859,31 @@
             ? existing.Merge(navProjection)
             : navProjection;
 
-    public static void SetProjectionMetadata(FieldType fieldType, LambdaExpression projection) =>
-        fieldType.Metadata["_EF_Projection"] = projection;
+    const string projectionKey = "_EF_Projection";
+    const string projectionPathsKey = "_EF_ProjectionPaths";
 
-    static bool TryGetProjectionMetadata(FieldType fieldType, [NotNullWhen(true)] out LambdaExpression? projection)
+    public static void SetProjectionMetadata(FieldType fieldType, LambdaExpression projection)
     {
-        if (fieldType.Metadata.TryGetValue("_EF_Projection", out var projectionObj))
+        fieldType.Metadata[projectionKey] = projection;
+        // Analyzed here, once, rather than on every request that selects the field
+        fieldType.Metadata[projectionPathsKey] = ProjectionPaths.Analyze(projection);
+    }
+
+    static bool TryGetProjectionMetadata(FieldType fieldType, [NotNullWhen(true)] out ProjectionPaths? projection)
+    {
+        var metadata = fieldType.Metadata;
+        if (metadata.TryGetValue(projectionPathsKey, out var pathsObj) &&
+            pathsObj is ProjectionPaths paths)
         {
-            projection = (LambdaExpression)projectionObj!;
+            projection = paths;
+            return true;
+        }
+
+        // The expression placed in the metadata directly, without the analysis
+        if (metadata.TryGetValue(projectionKey, out var projectionObj) &&
+            projectionObj is LambdaExpression expression)
+        {
+            projection = ProjectionPaths.Analyze(expression);
             return true;
         }
 

--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_List.cs
@@ -32,7 +32,10 @@ public static partial class ArgumentProcessor
         bool omitQueryArguments,
         bool argumentsAppliedInQuery)
     {
-        if (omitQueryArguments)
+        // A field selected without arguments has nothing to apply. Reading them anyway made
+        // GraphQL.NET build the argument dictionary, which it does lazily, per field per row.
+        if (omitQueryArguments ||
+            !ArgumentReader.HasArguments(context))
         {
             return items;
         }
@@ -42,20 +45,10 @@ public static partial class ArgumentProcessor
 
         if (!argumentsAppliedInQuery)
         {
-            if (keyNames is not null)
+            var predicate = PredicateCache.GetOrAdd(context, keyNames, static (keyNames, context) => BuildPredicate<TItem>(keyNames, context));
+            if (predicate is not null)
             {
-                if (ArgumentReader.TryReadIds(context, out var idValues))
-                {
-                    var keyName = GetKeyName(keyNames);
-                    var predicate = ExpressionBuilder<TItem>.BuildIdPredicate(keyName, idValues);
-                    items = items.Where(Compile(predicate));
-                }
-            }
-
-            if (ArgumentReader.TryReadWhere(context, out var wheres))
-            {
-                var predicate = ExpressionBuilder<TItem>.BuildPredicate(wheres);
-                items = items.Where(Compile(predicate));
+                items = items.Where(predicate);
             }
 
             (items, order) = Order(items, context);
@@ -79,9 +72,42 @@ public static partial class ArgumentProcessor
     }
 
     /// <summary>
-    /// This path runs once per parent node, so a navigation list field is compiled as many times as there
-    /// are parents. Emitting IL costs ~700us a call and leaves behind a DynamicMethod that is never
-    /// collected, which dwarfs the cost of running the predicate over an in memory collection. Interpreting
+    /// The ids and where of the field as one in memory predicate, or null when it has neither.
+    /// Built once per request per field, through <see cref="PredicateCache"/>, since the
+    /// arguments are the same for every parent row.
+    /// </summary>
+    static Func<TItem, bool>? BuildPredicate<TItem>(List<string>? keyNames, IResolveFieldContext context)
+    {
+        Func<TItem, bool>? ids = null;
+        if (keyNames is not null &&
+            ArgumentReader.TryReadIds(context, out var idValues))
+        {
+            var keyName = GetKeyName(keyNames);
+            ids = Compile(ExpressionBuilder<TItem>.BuildIdPredicate(keyName, idValues));
+        }
+
+        Func<TItem, bool>? where = null;
+        if (ArgumentReader.TryReadWhere(context, out var wheres))
+        {
+            where = Compile(ExpressionBuilder<TItem>.BuildPredicate(wheres));
+        }
+
+        if (ids is null)
+        {
+            return where;
+        }
+
+        if (where is null)
+        {
+            return ids;
+        }
+
+        return _ => ids(_) && where(_);
+    }
+
+    /// <summary>
+    /// Emitting IL costs ~700us a call and leaves behind a DynamicMethod that is never collected,
+    /// which dwarfs the cost of running the predicate over an in memory collection. Interpreting
     /// is ~20x cheaper to construct and stays ahead until a collection reaches several thousand items.
     /// </summary>
     static Func<TItem, bool> Compile<TItem>(Expression<Func<TItem, bool>> predicate) =>

--- a/src/GraphQL.EntityFramework/Where/ArgumentProcessor_Queryable.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentProcessor_Queryable.cs
@@ -10,7 +10,9 @@ public static partial class ArgumentProcessor
         bool omitQueryArguments)
         where TItem : class
     {
-        if (omitQueryArguments)
+        // A field selected without arguments has nothing to apply
+        if (omitQueryArguments ||
+            !ArgumentReader.HasArguments(context))
         {
             return queryable;
         }

--- a/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
+++ b/src/GraphQL.EntityFramework/Where/ArgumentReader.cs
@@ -15,6 +15,23 @@
         return false;
     }
 
+    /// <summary>
+    /// Whether the field was selected with any arguments. GraphQL.NET builds the argument
+    /// dictionary lazily, per field per row, so the ast is consulted instead: a field selected
+    /// without arguments has nothing to read, and that is the common case for a navigation.
+    /// A context built by hand, outside an execution, carries no ast, so its arguments are used.
+    /// </summary>
+    public static bool HasArguments(IResolveFieldContext context)
+    {
+        var field = context.FieldAst;
+        if (field is null)
+        {
+            return context.Arguments is { Count: > 0 };
+        }
+
+        return field.Arguments is { Count: > 0 };
+    }
+
     public static IReadOnlyCollection<OrderBy> ReadOrderBy(IResolveFieldContext context)
     {
         if (TryReadArgument(context, "orderBy", out var value) &&

--- a/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
+++ b/src/GraphQL.EntityFramework/Where/ExpressionBuilder.cs
@@ -16,7 +16,8 @@ public static partial class ExpressionBuilder<T>
     static Expression MakePredicateBody(IReadOnlyCollection<WhereExpression> wheres)
     {
         Expression? mainExpression = null;
-        var previousWhere = new WhereExpression();
+        // The connector on an expression joins it to the next one
+        var previousConnector = Connector.And;
 
         // Iterate over wheres
         foreach (var where in wheres)
@@ -62,11 +63,10 @@ public static partial class ExpressionBuilder<T>
             else
             {
                 // Otherwise combine expression by specified connector or default (AND) if not provided
-                mainExpression = CombineExpressions(previousWhere.Connector, mainExpression, nextExpression);
+                mainExpression = CombineExpressions(previousConnector, mainExpression, nextExpression);
             }
 
-            // Save the previous where so the connector can be retrieved
-            previousWhere = where;
+            previousConnector = where.Connector;
         }
 
         return mainExpression ?? Expression.Constant(false);

--- a/src/GraphQL.EntityFramework/Where/PredicateCache.cs
+++ b/src/GraphQL.EntityFramework/Where/PredicateCache.cs
@@ -1,0 +1,39 @@
+﻿/// <summary>
+/// The in memory predicate of a navigation list or connection field, compiled once per request.
+/// The field's resolver runs once per parent row, and building and interpreting the ids and
+/// where for every row cost about 4us a row. The arguments of a field are fixed for the request,
+/// literal or from variables, so the predicate is the same for every row. Keyed on the execution
+/// context, which is per request, since with document caching the ast nodes are shared between
+/// requests; the entries are collected with it. The item type is part of the key, since a field
+/// selected on an interface is one ast node resolved by each implementing type.
+/// </summary>
+static class PredicateCache
+{
+    static ConditionalWeakTable<object, ConcurrentDictionary<(GraphQLField Field, Type Item), object?>> predicates = new();
+
+    public static Func<TItem, bool>? GetOrAdd<TItem>(
+        IResolveFieldContext context,
+        List<string>? keyNames,
+        Func<List<string>?, IResolveFieldContext, Func<TItem, bool>?> build)
+    {
+        var key = context.ExecutionContext;
+        var field = context.FieldAst;
+        // A context built by hand, outside an execution, has no request to cache against
+        if (key is null ||
+            field is null)
+        {
+            return build(keyNames, context);
+        }
+
+        var forRequest = predicates.GetValue(key, _ => new());
+        var cacheKey = (field, typeof(TItem));
+        if (forRequest.TryGetValue(cacheKey, out var existing))
+        {
+            return (Func<TItem, bool>?) existing;
+        }
+
+        var predicate = build(keyNames, context);
+        forRequest[cacheKey] = predicate;
+        return predicate;
+    }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_past_the_end_is_empty.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_past_the_end_is_empty.verified.txt
@@ -15,7 +15,7 @@ order by p.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
       @p: 21,
-      @p1: 2
+      @p1: 3
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_past_the_end_is_empty.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_past_the_end_is_empty.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  target: {
+    Data: {
+      parentEntitiesConnection: {
+        items: []
+      }
+    }
+  },
+  sql: {
+    Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+offset @p rows fetch next @p1 rows only,
+    Parameters: {
+      @p: 21,
+      @p1: 2
+    }
+  }
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_skips_count.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_skips_count.verified.txt
@@ -1,8 +1,11 @@
 ﻿{
   target: {
     Data: {
-      interfaceGraphConnection: {
+      parentEntitiesConnection: {
         items: [
+          {
+            property: Value1
+          },
           {
             property: Value2
           }
@@ -12,16 +15,14 @@
   },
   sql: {
     Text:
-select   b.Id,
-         b.Discriminator,
-         b.Property,
-         b.Status
-from     BaseEntities as b
-order by b.Property
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
-      @p: 0,
-      @p1: 10
+      @p: 1,
+      @p1: 2
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_with_last_counts.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_items_only_with_last_counts.verified.txt
@@ -1,0 +1,35 @@
+﻿{
+  target: {
+    Data: {
+      parentEntitiesConnection: {
+        items: [
+          {
+            property: Value6
+          },
+          {
+            property: Value7
+          }
+        ]
+      }
+    }
+  },
+  sql: [
+    {
+      Text:
+select COUNT(*)
+from   ParentEntities as p
+    },
+    {
+      Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+offset @p rows fetch next @p1 rows only,
+      Parameters: {
+        @p: 6,
+        @p1: 2
+      }
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_counts.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_counts.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  target: {
+    Data: {
+      parentEntitiesConnection: {
+        pageInfo: {
+          hasNextPage: true,
+          hasPreviousPage: true,
+          endCursor: 2
+        },
+        items: [
+          {
+            property: Value1
+          },
+          {
+            property: Value2
+          }
+        ]
+      }
+    }
+  },
+  sql: [
+    {
+      Text:
+select COUNT(*)
+from   ParentEntities as p
+    },
+    {
+      Text:
+select   p.Id,
+         p.Property
+from     ParentEntities as p
+order by p.Property
+offset @p rows fetch next @p1 rows only,
+      Parameters: {
+        @p: 1,
+        @p1: 2
+      }
+    }
+  ]
+}

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_last_page.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_last_page.verified.txt
@@ -2,12 +2,17 @@
   target: {
     Data: {
       parentEntitiesConnection: {
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: true,
+          endCursor: 7
+        },
         items: [
           {
-            property: Value1
+            property: Value6
           },
           {
-            property: Value2
+            property: Value7
           }
         ]
       }
@@ -21,7 +26,7 @@ from     ParentEntities as p
 order by p.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
-      @p: 1,
+      @p: 6,
       @p1: 3
     }
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_past_the_end.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_past_the_end.verified.txt
@@ -2,14 +2,12 @@
   target: {
     Data: {
       parentEntitiesConnection: {
-        items: [
-          {
-            property: Value1
-          },
-          {
-            property: Value2
-          }
-        ]
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          endCursor: null
+        },
+        items: []
       }
     }
   },
@@ -21,7 +19,7 @@ from     ParentEntities as p
 order by p.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
-      @p: 1,
+      @p: 21,
       @p1: 3
     }
   }

--- a/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_peeks.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Connection_page_info_without_total_count_peeks.verified.txt
@@ -18,23 +18,16 @@
       }
     }
   },
-  sql: [
-    {
-      Text:
-select COUNT(*)
-from   ParentEntities as p
-    },
-    {
-      Text:
+  sql: {
+    Text:
 select   p.Id,
          p.Property
 from     ParentEntities as p
 order by p.Property
 offset @p rows fetch next @p1 rows only,
-      Parameters: {
-        @p: 1,
-        @p1: 2
-      }
+    Parameters: {
+      @p: 1,
+      @p1: 3
     }
-  ]
+  }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_requirements_loaded_by_base_typed_query.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_on_derived_type_requirements_loaded_by_base_typed_query.verified.txt
@@ -21,7 +21,7 @@ order by b.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
       @p: 0,
-      @p1: 10
+      @p1: 11
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
@@ -43,7 +43,7 @@ order by p0.Property,
          c.Id,
     Parameters: {
       @p: 0,
-      @p1: 10
+      @p1: 11
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Filter_with_projection_accesses_foreign_key.verified.txt
@@ -23,14 +23,8 @@
       }
     }
   },
-  sql: [
-    {
-      Text:
-select COUNT(*)
-from   ParentEntities as p
-    },
-    {
-      Text:
+  sql: {
+    Text:
 select   p0.Id,
          c.Id,
          c.ParentId,
@@ -47,10 +41,9 @@ from     (select   p.Id,
 order by p0.Property,
          p0.Id,
          c.Id,
-      Parameters: {
-        @p: 0,
-        @p1: 10
-      }
+    Parameters: {
+      @p: 0,
+      @p1: 10
     }
-  ]
+  }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
@@ -17,14 +17,8 @@
       }
     }
   },
-  sql: [
-    {
-      Text:
-select COUNT(*)
-from   ParentEntities as p
-    },
-    {
-      Text:
+  sql: {
+    Text:
 select   p0.Id,
          c.Id,
          c.ParentId,
@@ -41,10 +35,9 @@ from     (select   p.Id,
 order by p0.Property,
          p0.Id,
          c.Id,
-      Parameters: {
-        @p: 0,
-        @p1: 10
-      }
+    Parameters: {
+      @p: 0,
+      @p1: 10
     }
-  ]
+  }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Nested_connection_under_root_connection_projects_scalars.verified.txt
@@ -37,7 +37,7 @@ order by p0.Property,
          c.Id,
     Parameters: {
       @p: 0,
-      @p1: 10
+      @p1: 11
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_connection_query_filtering.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_connection_query_filtering.verified.txt
@@ -26,7 +26,7 @@ order by f.Property
 offset @p rows fetch next @p1 rows only,
     Parameters: {
       @p: 0,
-      @p1: 10
+      @p1: 11
     }
   }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_connection_query_filtering.verified.txt
+++ b/src/Tests/IntegrationTests/IntegrationTests.Simplified_filter_connection_query_filtering.verified.txt
@@ -17,23 +17,16 @@
       }
     }
   },
-  sql: [
-    {
-      Text:
-select COUNT(*)
-from   FilterParentEntities as f
-    },
-    {
-      Text:
+  sql: {
+    Text:
 select   f.Id,
          f.Property
 from     FilterParentEntities as f
 order by f.Property
 offset @p rows fetch next @p1 rows only,
-      Parameters: {
-        @p: 0,
-        @p1: 10
-      }
+    Parameters: {
+      @p: 0,
+      @p1: 10
     }
-  ]
+  }
 }

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -651,15 +651,69 @@
     }
 
     /// <summary>
-    /// The page info compares against the count, so selecting it without totalCount still runs the count query.
+    /// The page info without totalCount needs no count: the page query reads one row past the page, and that row answers hasNextPage.
     /// </summary>
     [Fact]
-    public async Task Connection_page_info_without_total_count_counts()
+    public async Task Connection_page_info_without_total_count_peeks()
     {
         var query =
             """
             {
               parentEntitiesConnection(first:2, after: "0") {
+                pageInfo {
+                  hasNextPage
+                  hasPreviousPage
+                  endCursor
+                }
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
+    /// <summary>
+    /// The last page has no row past it to read, so hasNextPage is false without the count.
+    /// </summary>
+    [Fact]
+    public async Task Connection_page_info_without_total_count_last_page()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first:2, after: "5") {
+                pageInfo {
+                  hasNextPage
+                  hasPreviousPage
+                  endCursor
+                }
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
+    /// <summary>
+    /// A page past the end is empty, which proves nothing about rows before it, so hasPreviousPage is false, as the spec allows when paging forward.
+    /// </summary>
+    [Fact]
+    public async Task Connection_page_info_without_total_count_past_the_end()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first:2, after: "20") {
                 pageInfo {
                   hasNextPage
                   hasPreviousPage

--- a/src/Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests/IntegrationTests.cs
@@ -650,6 +650,99 @@
         await RunQuery(database, query, null, null, false, entities.ToArray());
     }
 
+    /// <summary>
+    /// The page info compares against the count, so selecting it without totalCount still runs the count query.
+    /// </summary>
+    [Fact]
+    public async Task Connection_page_info_without_total_count_counts()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first:2, after: "0") {
+                pageInfo {
+                  hasNextPage
+                  hasPreviousPage
+                  endCursor
+                }
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
+    /// <summary>
+    /// Nothing selected reads the count, and first and after place the window from the start, so the count query is skipped and the page is a single query.
+    /// </summary>
+    [Fact]
+    public async Task Connection_items_only_skips_count()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first:2, after: "0") {
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
+    /// <summary>
+    /// Without the count the offset is not clamped to the end, so a page past it is read from the database as an empty page.
+    /// </summary>
+    [Fact]
+    public async Task Connection_items_only_past_the_end_is_empty()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(first:2, after: "20") {
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
+    /// <summary>
+    /// last places the window from the end, which needs the count even when nothing selected reads it.
+    /// </summary>
+    [Fact]
+    public async Task Connection_items_only_with_last_counts()
+    {
+        var query =
+            """
+            {
+              parentEntitiesConnection(last:2) {
+                items {
+                  property
+                }
+              }
+            }
+            """;
+        var entities = BuildEntities(8);
+
+        await using var database = await sqlInstance.Build();
+        await RunQuery(database, query, null, null, false, entities.ToArray());
+    }
+
     [Fact]
     public async Task Connection_page_back()
     {


### PR DESCRIPTION
## Per row overhead in the navigation resolvers

Measured with `RequestSplitBenchmark` (EF InMemory, 100 parents with 5 children each), the trees the library builds per request are about 0.2% of a request, as recorded before. What remained was per parent row in the navigation, navigation list and navigation connection resolvers: each built a `ResolveEfFieldContext` by copying every property of the GraphQL.NET context, which forced the lazily computed `SubFields`, `Path`, `ResponsePath`, `Parent` and `Arguments` to be computed and allocated for every row, when the resolver only needs the DbContext and the filters.

- The three resolvers resolve the DbContext and the filters directly.
- A field selected without arguments skips the argument reads and the push down lookup, since GraphQL.NET builds the argument dictionary lazily per field per row.
- The in memory ids and where predicate of a navigation field, on the path where the arguments are not pushed into the query, is compiled once per request per field rather than once per parent row (`PredicateCache`).
- A projection expression is analyzed once when its field is registered (`ProjectionPaths`), the walks over graph type hierarchies are cached per graph type, a selection set of plain fields skips the derived navigation scan, and the filter hierarchy lookup is cached per entity type.

| Benchmark | Before | After |
|---|---|---|
| Nested query, 100 parents | 2,858 us / 3,989 KB | 2,761 us / 3,924 KB |
| where and orderBy on a navigation evaluated in memory (new `FullWithInMemoryArguments`) | 4,052 us / 4,554 KB | 3,311 us / 4,144 KB |

The library's allocation beyond GraphQL.NET and EF fell from about 69 KB to about 4 KB per request. Timings carry 5-10% run to run noise on InMemory; the allocations are exact.

## One query per connection page

A root connection ran a COUNT query on every request. It now runs only when `totalCount` is selected, or when `last` or `before` place the window from the end. Otherwise the page query reads one row past `first`: that row answers `hasNextPage` and is dropped from the page before the filters run. `hasPreviousPage` without the count is true when the page starts after the first item and has rows; an empty page past the end reports false, which the Relay specification allows when paging forward.

The count scans every row matching the where, however small the page, where the page query stops after `first` rows. A Relay page fetch, which selects `pageInfo` and not `totalCount`, is one query instead of two, at the cost of one extra row per page.

Documented under paging, with tests for items only pages, a page past the end, `last`, and `pageInfo` without `totalCount` on a middle page, the last page and past the end.
